### PR TITLE
Queue events sent before WebSocket connection instead of dropping

### DIFF
--- a/src/createActorKitClient.ts
+++ b/src/createActorKitClient.ts
@@ -47,12 +47,13 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
 ): ActorKitClient<TMachine> {
   let currentSnapshot = props.initialSnapshot;
   let socket: WebSocket | null = null;
-  let socketReady = false;
+
   let shouldReconnect = true;
   const listeners: Set<Listener<CallerSnapshotFrom<TMachine>>> = new Set();
   const pendingEvents: ClientEventFrom<TMachine>[] = [];
   let reconnectAttempts = 0;
   const maxReconnectAttempts = 5;
+  const maxQueueSize = 100;
 
   /**
    * Notifies all registered listeners with the current state.
@@ -70,11 +71,10 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
     const url = getWebSocketUrl(props);
 
     socket = new WebSocket(url);
-    socketReady = false;
+
 
     socket.addEventListener("open", () => {
       reconnectAttempts = 0;
-      socketReady = true;
       flushPendingEvents();
     });
 
@@ -111,7 +111,7 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
     // later after it's disconnected
 
     socket.addEventListener("close", (_event) => {
-      socketReady = false;
+  
 
       // Implement reconnection logic
       if (shouldReconnect && reconnectAttempts < maxReconnectAttempts) {
@@ -137,7 +137,7 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
       socket.close();
       socket = null;
     }
-    socketReady = false;
+
   };
 
   const flushPendingEvents = () => {
@@ -160,13 +160,11 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
       return;
     }
 
-    if (socket && !socketReady) {
-      pendingEvents.push(event);
-    } else {
-      props.onError?.(
-        new Error("Cannot send event: WebSocket is not connected")
-      );
+    // Queue the event for delivery when connection is (re)established
+    if (pendingEvents.length >= maxQueueSize) {
+      pendingEvents.shift(); // Drop oldest
     }
+    pendingEvents.push(event);
   };
 
   /**

--- a/tests/create-actor-kit-client.test.ts
+++ b/tests/create-actor-kit-client.test.ts
@@ -283,15 +283,90 @@ describe("createActorKitClient", () => {
     expect(subscriber).toHaveBeenCalledOnce();
   });
 
-  it("reports an error when sending while disconnected", () => {
-    const onError = vi.fn();
-    const client = createTestClient({ onError });
+  it("queues events sent before connect and flushes them on open", async () => {
+    const client = createTestClient();
 
-    client.send({ type: "ADD_TODO", text: "Buy milk" });
+    // Send BEFORE calling connect — should queue, not error
+    client.send({ type: "ADD_TODO", text: "Before connect" });
+    client.send({ type: "ADD_TODO", text: "Also before" });
 
-    expect(onError).toHaveBeenCalledWith(
-      new Error("Cannot send event: WebSocket is not connected")
+    const connectionPromise = client.connect();
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    await connectionPromise;
+
+    expect(socket.sent).toEqual([
+      JSON.stringify({ type: "ADD_TODO", text: "Before connect" }),
+      JSON.stringify({ type: "ADD_TODO", text: "Also before" }),
+    ]);
+  });
+
+  it("queues events during reconnection and flushes on reconnect", async () => {
+    vi.useFakeTimers();
+
+    const client = createTestClient();
+    const connectionPromise = client.connect();
+    const firstSocket = MockWebSocket.instances[0];
+    firstSocket.open();
+    await connectionPromise;
+
+    // Disconnect
+    firstSocket.close();
+
+    // Send during disconnection — should queue
+    client.send({ type: "ADD_TODO", text: "During disconnect" });
+
+    // Reconnect
+    await vi.advanceTimersByTimeAsync(2000);
+    const secondSocket = MockWebSocket.instances[1];
+    secondSocket.open();
+
+    expect(secondSocket.sent).toEqual([
+      JSON.stringify({ type: "ADD_TODO", text: "During disconnect" }),
+    ]);
+  });
+
+  it("respects max queue size and drops oldest events", async () => {
+    const client = createTestClient();
+
+    // Queue more events than default max (100)
+    for (let i = 0; i < 105; i++) {
+      client.send({ type: "ADD_TODO", text: `Event ${i}` });
+    }
+
+    const connectionPromise = client.connect();
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    await connectionPromise;
+
+    // Should have dropped the oldest 5
+    expect(socket.sent).toHaveLength(100);
+    expect(JSON.parse(socket.sent[0])).toEqual({
+      type: "ADD_TODO",
+      text: "Event 5",
+    });
+    expect(JSON.parse(socket.sent[99])).toEqual({
+      type: "ADD_TODO",
+      text: "Event 104",
+    });
+  });
+
+  it("preserves queue order across multiple send calls", async () => {
+    const client = createTestClient();
+
+    client.send({ type: "ADD_TODO", text: "A" });
+    client.send({ type: "ADD_TODO", text: "B" });
+    client.send({ type: "ADD_TODO", text: "C" });
+
+    const connectionPromise = client.connect();
+    const socket = MockWebSocket.instances[0];
+    socket.open();
+    await connectionPromise;
+
+    const sentTexts = socket.sent.map(
+      (s) => (JSON.parse(s) as TestEvent).text
     );
+    expect(sentTexts).toEqual(["A", "B", "C"]);
   });
 
   it("does not throw when optional error callbacks are omitted", async () => {
@@ -303,6 +378,7 @@ describe("createActorKitClient", () => {
 
     expect(() => socket.emitMessage("{bad-json")).not.toThrow();
     expect(() => socket.emitError("socket")).not.toThrow();
+    // Sending while disconnected now queues — should not throw
     client.disconnect();
     expect(() =>
       client.send({ type: "ADD_TODO", text: "No callback installed" })


### PR DESCRIPTION
## Summary

Events sent before `connect()` or during WebSocket reconnection are now queued (max 100, oldest dropped on overflow) and flushed when the connection opens.

**Before:** `send()` called before `connect()` triggered an error callback and the event was silently lost. This caused data loss during fast user interactions on page load.

**After:** All events queue until the socket is open. Queue drains automatically on connect/reconnect. Max size prevents unbounded memory growth.

### Changes
- `send()` always queues when socket isn't open (removed error-on-no-socket path)
- Max queue size of 100 (drops oldest on overflow)
- Removed unused `socketReady` variable
- 4 new tests covering pre-connect queuing, reconnect queuing, max queue overflow, and order preservation

Implements [Proposal 002](docs/roadmap/002-event-queuing.md).

## Test plan
- [x] 50 unit tests pass (4 new + 46 existing)
- [x] Lint + typecheck pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)