### PR TITLE
Replace 32-bit hash with SHA-256 for snapshot checksums

### DIFF
--- a/src/createMachineServer.ts
+++ b/src/createMachineServer.ts
@@ -244,13 +244,13 @@ export const createMachineServer = <
       }
     }
 
-    #sendStateUpdate(ws: ActorKitWebSocket) {
+    async #sendStateUpdate(ws: ActorKitWebSocket) {
       assert(this.actor, "actor is not running");
       const attachment = this.attachments.get(ws);
       assert(attachment, "Attachment missing for WebSocket");
 
       const fullSnapshot = this.actor.getSnapshot();
-      const currentChecksum = this.#calculateChecksum(fullSnapshot);
+      const currentChecksum = await this.#calculateChecksum(fullSnapshot);
 
       this.snapshotCache.set(currentChecksum, {
         snapshot: fullSnapshot,
@@ -507,18 +507,18 @@ export const createMachineServer = <
       this.#ensureActorRunning();
 
       if (!options?.waitForEvent && !options?.waitForState) {
-        return this.#getCurrentSnapshot(caller);
+        return await this.#getCurrentSnapshot(caller);
       }
 
       const timeoutPromise = new Promise<{
         checksum: string;
         snapshot: CallerSnapshotFrom<TMachine>;
       }>((resolve, reject) => {
-        setTimeout(() => {
+        setTimeout(async () => {
           if (options.errorOnWaitTimeout !== false) {
             reject(new Error("Timeout waiting for event or state"));
           } else {
-            resolve(this.#getCurrentSnapshot(caller));
+            resolve(await this.#getCurrentSnapshot(caller));
           }
         }, options.timeout ?? 5000);
       });
@@ -527,7 +527,7 @@ export const createMachineServer = <
         checksum: string;
         snapshot: CallerSnapshotFrom<TMachine>;
       }>((resolve) => {
-        const subscription = this.actor?.subscribe((snapshot) => {
+        const subscription = this.actor?.subscribe(async (snapshot) => {
           if (
             (options.waitForEvent &&
               this.#matchesEvent(snapshot, options.waitForEvent)) ||
@@ -535,7 +535,7 @@ export const createMachineServer = <
               this.#matchesState(snapshot, options.waitForState))
           ) {
             subscription?.unsubscribe();
-            resolve(this.#getCurrentSnapshot(caller));
+            resolve(await this.#getCurrentSnapshot(caller));
           }
         });
       });
@@ -543,12 +543,12 @@ export const createMachineServer = <
       return Promise.race([waitPromise, timeoutPromise]);
     }
 
-    #getCurrentSnapshot(caller: Caller) {
+    async #getCurrentSnapshot(caller: Caller) {
       const fullSnapshot = this.actor?.getSnapshot();
       assert(fullSnapshot, "Actor snapshot is not available");
       return {
         snapshot: this.#createCallerSnapshot(fullSnapshot, caller.id),
-        checksum: this.#calculateChecksum(fullSnapshot),
+        checksum: await this.#calculateChecksum(fullSnapshot),
       };
     }
 
@@ -566,18 +566,12 @@ export const createMachineServer = <
       return matchesState(stateValue, snapshot);
     }
 
-    #calculateChecksum(snapshot: SnapshotFrom<TMachine>) {
-      return this.#hashString(JSON.stringify(snapshot));
-    }
-
-    #hashString(value: string) {
-      let hash = 0;
-      for (let index = 0; index < value.length; index += 1) {
-        const character = value.charCodeAt(index);
-        hash = (hash << 5) - hash + character;
-        hash &= hash;
-      }
-      return hash.toString(16);
+    async #calculateChecksum(snapshot: SnapshotFrom<TMachine>) {
+      const str = JSON.stringify(snapshot);
+      const buffer = new TextEncoder().encode(str);
+      const hash = await crypto.subtle.digest("SHA-256", buffer);
+      const array = new Uint8Array(hash);
+      return Array.from(array, (b) => b.toString(16).padStart(2, "0")).join("");
     }
 
     #createCallerSnapshot(

--- a/tests/create-machine-server.test.ts
+++ b/tests/create-machine-server.test.ts
@@ -320,6 +320,8 @@ describe("createMachineServer", () => {
     );
 
     expect(response.status).toBe(101);
+    // Wait for async checksum computation to complete
+    await new Promise((r) => setTimeout(r, 10));
     const acceptedSocket = state.getWebSockets()[0];
     expect(acceptedSocket).toBeDefined();
     expect(acceptedSocket?.sent).toHaveLength(1);
@@ -419,6 +421,90 @@ describe("createMachineServer", () => {
       "Second",
       "Third",
     ]);
+  });
+
+  it("produces collision-resistant checksums (64-char hex)", async () => {
+    const state = new FakeDurableObjectState();
+    const server = new TodoServer(state, {
+      ACTOR_KIT_SECRET: "super-secret",
+      EMAIL_SERVICE_API_KEY: "key",
+    });
+    await state.idle();
+
+    await server.spawn({
+      actorType: "todo",
+      actorId: "list-1",
+      caller: { id: "user-1", type: "client" },
+      input: { foo: "bar" },
+    });
+
+    const snap1 = await server.getSnapshot({ id: "user-1", type: "client" });
+
+    // SHA-256 hex should be 64 characters
+    expect(snap1.checksum).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces different checksums for different states", async () => {
+    const state = new FakeDurableObjectState();
+    const server = new TodoServer(state, {
+      ACTOR_KIT_SECRET: "super-secret",
+      EMAIL_SERVICE_API_KEY: "key",
+    });
+    await state.idle();
+
+    await server.spawn({
+      actorType: "todo",
+      actorId: "list-1",
+      caller: { id: "user-1", type: "client" },
+      input: { foo: "bar" },
+    });
+
+    const snap1 = await server.getSnapshot({ id: "user-1", type: "client" });
+
+    server.send({
+      type: "ADD_TODO",
+      text: "Change state",
+      caller: { id: "user-1", type: "client" },
+    });
+    await Promise.resolve();
+
+    const snap2 = await server.getSnapshot({ id: "user-1", type: "client" });
+
+    expect(snap1.checksum).not.toBe(snap2.checksum);
+    expect(snap2.checksum).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces identical checksums for identical states", async () => {
+    // Two separate servers with the same state should produce the same checksum
+    const state1 = new FakeDurableObjectState();
+    const state2 = new FakeDurableObjectState();
+    const env = {
+      ACTOR_KIT_SECRET: "super-secret",
+      EMAIL_SERVICE_API_KEY: "key",
+    };
+
+    const server1 = new TodoServer(state1, env);
+    await state1.idle();
+    const server2 = new TodoServer(state2, env);
+    await state2.idle();
+
+    await server1.spawn({
+      actorType: "todo",
+      actorId: "list-1",
+      caller: { id: "user-1", type: "client" },
+      input: { foo: "bar" },
+    });
+    await server2.spawn({
+      actorType: "todo",
+      actorId: "list-1",
+      caller: { id: "user-1", type: "client" },
+      input: { foo: "bar" },
+    });
+
+    const snap1 = await server1.getSnapshot({ id: "user-1", type: "client" });
+    const snap2 = await server2.getSnapshot({ id: "user-1", type: "client" });
+
+    expect(snap1.checksum).toBe(snap2.checksum);
   });
 
   it("preserves todo completion state across restart", async () => {


### PR DESCRIPTION
## Summary

Replaces the 32-bit string hash used for snapshot checksums with SHA-256 via Web Crypto API.

**Before:** Simple bitwise hash producing ~4 billion unique values. By the birthday paradox, collision probability exceeds 50% after ~77K unique states. A collision means the server skips a state patch, silently desyncing the client.

**After:** SHA-256 produces 64-char hex checksums with negligible collision probability (2^256 space).

### Changes
- `#calculateChecksum` now uses `crypto.subtle.digest("SHA-256")`
- `#sendStateUpdate` and `#getCurrentSnapshot` are now async (required by Web Crypto)
- 3 new tests: SHA-256 format validation, different-state divergence, same-state convergence

### Breaking change consideration
Clients with old-format short checksums won't match on reconnect. The server already handles this — checksum mismatch triggers a full state send. No migration needed.

Implements [Proposal 008](docs/roadmap/008-better-checksums.md).

## Test plan
- [x] 53 unit tests pass (3 new + 50 existing)
- [x] Lint + typecheck pass
- [ ] CI green (including E2E against preview deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)