### PR TITLE
Switch persistence to getPersistedSnapshot() for deep actor support

### DIFF
--- a/src/createMachineServer.ts
+++ b/src/createMachineServer.ts
@@ -7,6 +7,7 @@ import {
   EventFromLogic,
   InputFrom,
   matchesState,
+  Snapshot,
   SnapshotFrom,
   StateValueFrom,
   Subscription,
@@ -130,7 +131,7 @@ export const createMachineServer = <
     actorId: string | undefined;
     input: Record<string, unknown> | undefined;
     initialCaller: Caller | undefined;
-    lastPersistedSnapshot: SnapshotFrom<TMachine> | null = null;
+    lastPersistedSnapshot: Snapshot<unknown> | null = null;
     snapshotCache = new Map<
       string,
       { snapshot: SnapshotFrom<TMachine>; timestamp: number }
@@ -291,14 +292,14 @@ export const createMachineServer = <
 
     #setupStatePersistence(actor: Actor<TMachine>) {
       actor.subscribe(() => {
-        const fullSnapshot = actor.getSnapshot();
-        this.#persistSnapshot(fullSnapshot).catch(() => {
+        const persistedSnapshot = actor.getPersistedSnapshot();
+        this.#persistSnapshot(persistedSnapshot).catch(() => {
           // Ignore persistence errors.
         });
       });
     }
 
-    async #persistSnapshot(snapshot: SnapshotFrom<TMachine>) {
+    async #persistSnapshot(snapshot: ReturnType<Actor<TMachine>["getPersistedSnapshot"]>) {
       if (
         this.lastPersistedSnapshot &&
         compare(this.lastPersistedSnapshot, snapshot).length === 0

--- a/tests/create-machine-server.test.ts
+++ b/tests/create-machine-server.test.ts
@@ -507,6 +507,46 @@ describe("createMachineServer", () => {
     expect(snap1.checksum).toBe(snap2.checksum);
   });
 
+  it("uses getPersistedSnapshot for persistence, not getSnapshot", async () => {
+    const state = new FakeDurableObjectState();
+    const env = {
+      ACTOR_KIT_SECRET: "super-secret",
+      EMAIL_SERVICE_API_KEY: "key",
+    };
+
+    const server = new TodoServer(state, env);
+    await state.idle();
+
+    await server.spawn({
+      actorType: "todo",
+      actorId: "list-1",
+      caller: { id: "user-1", type: "client" },
+      input: { foo: "bar" },
+    });
+
+    server.send({
+      type: "ADD_TODO",
+      text: "Persist test",
+      caller: { id: "user-1", type: "client" },
+    });
+    await Promise.resolve();
+
+    // Read the persisted snapshot from storage
+    const persisted = await state.storage.get("persistedSnapshot");
+    expect(persisted).toBeDefined();
+
+    const parsed = JSON.parse(persisted as string);
+    // Verify the persisted snapshot has the XState persisted format
+    // getPersistedSnapshot includes children map for deep persistence
+    expect(parsed).toHaveProperty("status");
+    expect(parsed.status).toBe("active");
+    expect(parsed).toHaveProperty("value");
+    expect(parsed).toHaveProperty("context");
+    // getPersistedSnapshot includes "children" for deep persistence of
+    // invoked/spawned actors — getSnapshot does not
+    expect(parsed).toHaveProperty("children");
+  });
+
   it("preserves todo completion state across restart", async () => {
     const state = new FakeDurableObjectState();
     const env = {


### PR DESCRIPTION
## Summary

Switches from `actor.getSnapshot()` to `actor.getPersistedSnapshot()` for state persistence. This is the correct XState API for serializing actor state, as it recursively persists child actor state and strips non-serializable data.

**Impact:** Critical for machines with invoked/spawned actors (e.g., Piqolo's player actor invoking a profile actor). For simple machines, both methods produce equivalent output, but using the wrong method silently loses child actor state on DO restart.

Implements Phase 1 step 1 of [Proposal 012](docs/roadmap/012-sqlite-storage-layer.md).

## Test plan
- [x] 54 unit tests pass (1 new verifying persisted snapshot format)
- [x] Lint + typecheck pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)