### PR TITLE
deps: bump xstate-migrate to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lint": "eslint src tests vitest.config.ts eslint.config.js && pnpm --filter nextjs-actorkit-todo lint && pnpm --filter tanstack-start-actorkit-todo lint",
     "test": "pnpm run test:unit",
     "test:unit": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:build-fixtures": "cd tests/integration/fixtures && npx wrangler deploy --dry-run --outdir=dist",
     "test:coverage": "vitest run --coverage",
     "test:mutate": "NODE_OPTIONS=--max-old-space-size=8192 stryker run",
@@ -105,7 +106,7 @@
     "typescript-eslint": "^8.57.0",
     "vitest": "^4.1.0",
     "xstate": "^5.28.0",
-    "xstate-migrate": "^0.0.5",
+    "xstate-migrate": "^0.0.7",
     "zod": "^3.25.76"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^5.28.0
         version: 5.28.0
       xstate-migrate:
-        specifier: ^0.0.5
-        version: 0.0.5(xstate@5.28.0)
+        specifier: ^0.0.7
+        version: 0.0.7(xstate@5.28.0)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -5580,10 +5580,10 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  xstate-migrate@0.0.5:
-    resolution: {integrity: sha512-9cbdBh7gNLQHYabqAbl7m9iggfzRtu2eHpysVs67Rp1qsa7Weaca1v8az1Rhhz5ILgNzOM6esgpuCuAIT5xhkQ==}
+  xstate-migrate@0.0.7:
+    resolution: {integrity: sha512-hTNqwYlS+b4Kk0CGu3CgUZVFrupU2Bwczt0mFlEbACNv7lBRVOGdTOv0mMf7Xk7LlYU9ynRXBhzzECRQU7T9Gg==}
     peerDependencies:
-      xstate: ^5.15.0
+      xstate: ^5.28.0
 
   xstate@5.28.0:
     resolution: {integrity: sha512-Iaqq6ZrUzqeUtA3hC5LQKZfR8ZLzEFTImMHJM3jWEdVvXWdKvvVLXZEiNQWm3SCA9ZbEou/n5rcsna1wb9t28A==}
@@ -11068,7 +11068,7 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
-  xstate-migrate@0.0.5(xstate@5.28.0):
+  xstate-migrate@0.0.7(xstate@5.28.0):
     dependencies:
       fast-json-patch: 3.1.1
       xstate: 5.28.0


### PR DESCRIPTION
## Summary

- Bumps `xstate-migrate` from `^0.0.5` to `^0.0.7`
- Picks up fix for dotted machine ID state validation bug (valid nested states were incorrectly replaced when machine ID contained dots like `"my.app"`)
- Bug was found via TLA+ formal verification in [xstate-migrate#2](https://github.com/actor-kit/xstate-migrate/pull/2)

## Test plan

- [x] 77/77 actor-kit unit tests passing
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)