### PR TITLE
Separate unit and integration test commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,14 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Unit tests
+        run: pnpm run test:unit
+
       - name: Build test fixtures
         run: pnpm run test:build-fixtures
 
-      - name: Unit and integration tests
-        run: pnpm run test:unit
+      - name: Integration tests
+        run: pnpm run test:integration
 
   nextjs-e2e:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ test-results
 reports
 .stryker-tmp
 .swarm
+.ralph/
+docs/specs/states/
+docs/specs/tla2tools.jar

--- a/package.json
+++ b/package.json
@@ -42,10 +42,11 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "lint": "eslint src tests vitest.config.ts eslint.config.js && pnpm --filter nextjs-actorkit-todo lint && pnpm --filter tanstack-start-actorkit-todo lint",
+    "lint": "eslint src tests vitest.config.ts vitest.integration.config.ts eslint.config.js && pnpm --filter nextjs-actorkit-todo lint && pnpm --filter tanstack-start-actorkit-todo lint",
     "test": "pnpm run test:unit",
     "test:unit": "vitest run",
-    "test:build-fixtures": "cd tests/integration/fixtures && npx wrangler deploy --dry-run --outdir=dist",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:build-fixtures": "npx wrangler deploy --dry-run --outdir=dist --config tests/integration/fixtures/wrangler.toml",
     "test:coverage": "vitest run --coverage",
     "test:mutate": "NODE_OPTIONS=--max-old-space-size=8192 stryker run",
     "test:mutate:incremental": "NODE_OPTIONS=--max-old-space-size=8192 stryker run --incremental",

--- a/tests/integration/miniflare-sync.test.ts
+++ b/tests/integration/miniflare-sync.test.ts
@@ -31,7 +31,7 @@ function parseMessage(data: string): StateUpdateMessage {
   return JSON.parse(data) as StateUpdateMessage;
 }
 
-describe("Miniflare integration: createMachineServer", { timeout: 15000 }, () => {
+describe("Miniflare integration: createMachineServer", () => {
   let mf: Miniflare;
   // Use unique actor IDs per test to avoid state leakage between tests
   let testCounter = 0;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    exclude: ["tests/integration/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/integration/**/*.test.ts"],
+    testTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary

Split `test:unit` (which was running everything) into two distinct commands:

- **`test:unit`** — fast tests with fakes only (59 tests, ~4s)
- **`test:integration`** — Miniflare tests under real Workers runtime (18 tests, ~15s)

CI runs them as separate steps with clear labels. Unit tests run first (fast feedback), then fixtures are built, then integration tests run.

## Changes

- `vitest.config.ts` — excludes `tests/integration/**`
- `vitest.integration.config.ts` — new config for integration tests with 15s timeout
- `package.json` — adds `test:integration` script, updates lint to include new config
- `.github/workflows/ci.yml` — separate "Unit tests" and "Integration tests" steps
- `miniflare-sync.test.ts` — removes inline timeout (handled by config)

## Test plan

- [x] `pnpm test:unit` — 59 tests (no integration)
- [x] `pnpm test:integration` — 18 tests (only integration)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [ ] CI quality job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)