### PR TITLE
Fix circular generic in createMachineServer

### DIFF
--- a/src/createMachineServer.ts
+++ b/src/createMachineServer.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import { PERSISTED_SNAPSHOT_KEY } from "./constants";
 import { CallerSchema } from "./schemas";
 import type {
+  ActorKitEnv,
   ActorKitInputProps,
   ActorKitStateMachine,
   ActorKitStorage,
@@ -24,7 +25,6 @@ import type {
   Caller,
   CallerSnapshotFrom,
   ClientEventFrom,
-  EnvFromMachine,
   MachineServerOptions,
   ServiceEventFrom,
   WithActorKitContext,
@@ -92,6 +92,7 @@ export const createMachineServer = <
   TClientEvent extends AnyEventObject,
   TServiceEvent extends AnyEventObject,
   TInputSchema extends z.ZodObject<z.ZodRawShape>,
+  TEnv extends ActorKitEnv,
   TMachine extends ActorKitStateMachine<
     (
       | WithActorKitEvent<TClientEvent, "client">
@@ -99,7 +100,7 @@ export const createMachineServer = <
       | ActorKitSystemEvent
     ) & {
       storage: ActorKitStorage;
-      env: EnvFromMachine<TMachine>;
+      env: TEnv;
     },
     z.infer<TInputSchema> & {
       id: string;
@@ -122,7 +123,7 @@ export const createMachineServer = <
   options?: MachineServerOptions;
 }): new (
   state: DurableObjectState,
-  env: EnvFromMachine<TMachine>
+  env: TEnv
 ) => ActorServer<TMachine> =>
   class MachineServerImpl extends DurableObject implements ActorServer<TMachine> {
     actor: Actor<TMachine> | undefined;
@@ -140,10 +141,10 @@ export const createMachineServer = <
     attachments = new Map<WebSocket, WebSocketAttachment>();
     subscriptions = new Map<WebSocket, Subscription>();
     #sendQueues = new Map<WebSocket, Promise<void>>();
-    env: EnvFromMachine<TMachine>;
+    env: TEnv;
     currentChecksum: string | null = null;
 
-    constructor(state: DurableObjectState, env: EnvFromMachine<TMachine>) {
+    constructor(state: DurableObjectState, env: TEnv) {
       super(state, env);
       this.state = state;
       this.storage = state.storage;

--- a/tests/create-machine-server-types.test.ts
+++ b/tests/create-machine-server-types.test.ts
@@ -1,0 +1,122 @@
+import { describe, expectTypeOf, it, vi } from "vitest";
+
+vi.mock("cloudflare:workers", () => ({
+  DurableObject: class DurableObject {
+    constructor(
+      public readonly state: unknown,
+      public readonly env: unknown
+    ) {}
+  },
+}));
+
+import type {
+  ActorKitEnv,
+  ActorKitStateMachine,
+  ActorKitSystemEvent,
+  BaseActorKitEvent,
+  WithActorKitEvent,
+  WithActorKitInput,
+} from "../src/types";
+import { createMachineServer } from "../src/createMachineServer";
+import { setup } from "xstate";
+import { z } from "zod";
+
+// Custom env extending ActorKitEnv with extra bindings
+interface CustomEnv extends ActorKitEnv {
+  EMAIL_API_KEY: string;
+  DATABASE_URL: string;
+}
+
+// Client events
+type AddTodo = { type: "ADD_TODO"; text: string };
+type ClientEvent = AddTodo;
+
+// Service events
+type SyncTodos = {
+  type: "SYNC_TODOS";
+  todos: Array<{ id: string; text: string }>;
+};
+type ServiceEvent = SyncTodos;
+
+// Full event type using custom env
+type MachineEvent = (
+  | WithActorKitEvent<ClientEvent, "client">
+  | WithActorKitEvent<ServiceEvent, "service">
+  | ActorKitSystemEvent
+) &
+  BaseActorKitEvent<CustomEnv>;
+
+type MachineInput = WithActorKitInput<{ foo: string }, CustomEnv>;
+
+type MachineContext = {
+  public: { ownerId: string; todos: Array<{ id: string; text: string }> };
+  private: Record<string, { lastAccess: number }>;
+};
+
+const testMachine = setup({
+  types: {
+    context: {} as MachineContext,
+    events: {} as MachineEvent,
+    input: {} as MachineInput,
+  },
+}).createMachine({
+  id: "test",
+  context: ({ input }) => ({
+    public: { ownerId: input.caller.id, todos: [] },
+    private: {},
+  }),
+  on: {
+    ADD_TODO: {
+      actions: () => {},
+    },
+  },
+}) satisfies ActorKitStateMachine<MachineEvent, MachineInput, MachineContext>;
+
+const ClientEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("ADD_TODO"), text: z.string() }),
+]);
+
+const ServiceEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("SYNC_TODOS"),
+    todos: z.array(z.object({ id: z.string(), text: z.string() })),
+  }),
+]);
+
+const InputPropsSchema = z.object({ foo: z.string() });
+
+// Create the server once at module scope to avoid lint warnings
+const TestServer = createMachineServer({
+  machine: testMachine,
+  schemas: {
+    clientEvent: ClientEventSchema,
+    serviceEvent: ServiceEventSchema,
+    inputProps: InputPropsSchema,
+  },
+});
+
+type TestServerConstructorParams = ConstructorParameters<typeof TestServer>;
+type InferredEnv = TestServerConstructorParams[1];
+
+describe("createMachineServer type inference", () => {
+  it("accepts a machine without `as any` cast and infers custom env", () => {
+    // If the circular generic were still present, the createMachineServer
+    // call above would require `machine: testMachine as any` to compile.
+    // Verify the constructor requires the custom env type.
+    expectTypeOf(TestServer).constructorParameters.toMatchTypeOf<
+      [state: unknown, env: CustomEnv]
+    >();
+  });
+
+  it("infers custom env bindings on the constructor", () => {
+    expectTypeOf<InferredEnv>().toHaveProperty("ACTOR_KIT_SECRET");
+    expectTypeOf<InferredEnv>().toHaveProperty("EMAIL_API_KEY");
+    expectTypeOf<InferredEnv>().toHaveProperty("DATABASE_URL");
+  });
+
+  it("rejects plain ActorKitEnv when custom env bindings are required", () => {
+    // Plain ActorKitEnv should NOT satisfy the inferred env
+    // (it's missing EMAIL_API_KEY and DATABASE_URL)
+    expectTypeOf<ActorKitEnv>().not.toMatchTypeOf<InferredEnv>();
+  });
+});


### PR DESCRIPTION
## Summary

- `TMachine`'s constraint referenced itself via `EnvFromMachine<TMachine>`, which TypeScript can't resolve — forcing every consumer to cast `machine: myMachine as any`
- Extracted `TEnv extends ActorKitEnv` as an independent generic parameter so the env type is inferred without circularity
- Constructor return type now uses `TEnv` directly, giving callers proper env type inference

## Impact

Consumers (trivia-jam, remix-workers-app) can remove their `as any` casts:

```diff
 export const Game = createMachineServer({
-  machine: gameMachine as any,  // forced by circular generic
+  machine: gameMachine,         // env type inferred correctly
   schemas: { ... },
 });
```

The constructor also properly enforces custom env bindings at compile time.

## Test plan

- [x] All 62 existing unit tests pass
- [x] Added 3 type-level tests (`create-machine-server-types.test.ts`) verifying:
  - Machine with custom env compiles without `as any`
  - Constructor infers custom env bindings (`EMAIL_API_KEY`, `DATABASE_URL`)
  - Plain `ActorKitEnv` is rejected when custom env bindings are required
- [x] Lint + typecheck pass
- [ ] After merge + publish, verify trivia-jam/remix-workers-app can remove `as any` casts

🤖 Generated with [Claude Code](https://claude.com/claude-code)