### PR TITLE
WIP: Add fromActorKit for DO-to-DO communication

### DIFF
--- a/src/fromActorKit.ts
+++ b/src/fromActorKit.ts
@@ -1,0 +1,267 @@
+import { applyPatch } from "fast-json-patch";
+import type { Operation } from "fast-json-patch";
+import { produce } from "immer";
+import type { CallbackLogicFunction } from "xstate";
+import { fromCallback } from "xstate";
+import type { z } from "zod";
+import { createAccessToken } from "./createAccessToken";
+import type {
+  ActorKitEmittedEvent,
+  ActorServer,
+  AnyActorKitStateMachine,
+  Caller,
+  CallerSnapshotFrom,
+} from "./types";
+
+// --- Type utilities ---
+
+/** Convert kebab-case to SCREAMING_SNAKE_CASE: "my-actor" → "MY_ACTOR" */
+type KebabToScreamingSnake<S extends string> = string extends S
+  ? string
+  : S extends `${infer T}-${infer U}`
+    ? `${Uppercase<T>}_${KebabToScreamingSnake<U>}`
+    : Uppercase<S>;
+
+/** Events emitted back to the parent machine by the fromActorKit callback */
+export type FromActorKitEmitted<
+  TActorType extends string,
+  TMachine extends AnyActorKitStateMachine,
+> =
+  | {
+      type: `${KebabToScreamingSnake<TActorType>}_UPDATED`;
+      actorType: TActorType;
+      actorId: string;
+      snapshot: CallerSnapshotFrom<TMachine>;
+      operations: Operation[];
+    }
+  | {
+      type: `${KebabToScreamingSnake<TActorType>}_ERROR`;
+      actorType: TActorType;
+      actorId: string;
+      error: Error;
+    };
+
+/** Input required to invoke a fromActorKit callback actor */
+export type FromActorKitInput<
+  TMachine extends AnyActorKitStateMachine,
+  TEventSchema extends z.ZodTypeAny = z.ZodTypeAny,
+> = {
+  /** DurableObject namespace binding for the remote actor (e.g., env.ZONE) */
+  server: DurableObjectNamespace<ActorServer<TMachine>>;
+  /** ID of the remote actor instance */
+  actorId: string;
+  /** Input props to pass when spawning the remote actor */
+  actorInput: Record<string, unknown>;
+  /** Caller identity for JWT signing */
+  caller: Caller;
+  /** Secret key for JWT signing */
+  signingKey: string;
+  /** Zod schema to validate outbound events before forwarding */
+  eventSchema: TEventSchema;
+};
+
+/** Convert kebab-case to SCREAMING_SNAKE_CASE at runtime */
+function toScreamingSnake(str: string): string {
+  return str.replace(/-/g, "_").toUpperCase();
+}
+
+/**
+ * Creates an XState callback actor that connects to a remote actor-kit
+ * Durable Object via WebSocket.
+ *
+ * The callback:
+ * 1. Creates a JWT access token for the remote actor
+ * 2. Opens a WebSocket to the remote DO via stub.fetch()
+ * 3. Receives snapshot patches and emits {ACTOR_TYPE}_UPDATED events
+ * 4. Forwards events from the parent to the remote DO (validated via eventSchema)
+ * 5. Emits {ACTOR_TYPE}_ERROR on WebSocket errors
+ *
+ * @example
+ * ```typescript
+ * const sessionMachine = setup({
+ *   actors: {
+ *     zoneConnection: fromActorKit<ZoneMachine>("zone"),
+ *   },
+ * }).createMachine({
+ *   invoke: {
+ *     id: "zoneConnection",
+ *     src: "zoneConnection",
+ *     input: ({ context }) => ({
+ *       server: context.env.ZONE,
+ *       actorId: context.public.zoneId,
+ *       actorInput: {},
+ *       caller: { id: context.public.playerId, type: "service" },
+ *       signingKey: context.env.ACTOR_KIT_SECRET,
+ *       eventSchema: ZoneServiceEventSchema,
+ *     }),
+ *   },
+ *   on: {
+ *     ZONE_UPDATED: { actions: "updateZoneSnapshot" },
+ *   },
+ * });
+ * ```
+ */
+export function fromActorKit<
+  TMachine extends AnyActorKitStateMachine,
+  TActorType extends string = string,
+>(actorType: TActorType) {
+  type TEmitted = FromActorKitEmitted<TActorType, TMachine>;
+  type TInput = FromActorKitInput<TMachine>;
+
+  const ACTOR_TYPE_SNAKE = toScreamingSnake(actorType);
+
+  const callback: CallbackLogicFunction<
+    // Events the parent can send TO this callback
+    Record<string, unknown> & { type: string },
+    // Events this callback sends BACK to the parent
+    TEmitted,
+    // Input
+    TInput
+  > = ({ sendBack, receive, input }) => {
+    let websocket: WebSocket | null = null;
+    const pendingEvents: string[] = [];
+
+    const id = input.server.idFromName(input.actorId);
+    const stub = input.server.get(id);
+
+    createAccessToken({
+      signingKey: input.signingKey,
+      actorId: input.actorId,
+      actorType,
+      callerId: input.caller.id,
+      callerType: input.caller.type,
+    })
+      .then(async (accessToken) => {
+        // Spawn the remote actor if not already running (idempotent).
+        // Cast needed: DurableObjectStub<T> doesn't expose RPC methods in
+        // current CF types without Rpc.DurableObjectBranded. TODO: update
+        // ActorServer to use proper RPC types.
+        await Promise.resolve(
+          (stub as unknown as ActorServer<TMachine>).spawn({
+            actorType,
+            actorId: input.actorId,
+            caller: input.caller,
+            input: input.actorInput,
+          })
+        );
+
+        const response = await stub.fetch(
+          new Request(
+            `https://internal/api/${actorType}/${input.actorId}/?accessToken=${accessToken}`,
+            {
+              headers: {
+                Upgrade: "websocket",
+              },
+            }
+          )
+        );
+
+        websocket = (response as unknown as { webSocket: WebSocket }).webSocket;
+        if (!websocket) {
+          sendBack({
+            type: `${ACTOR_TYPE_SNAKE}_ERROR`,
+            actorType,
+            actorId: input.actorId,
+            error: new Error(
+              `WebSocket connection failed for ${actorType}/${input.actorId}`
+            ),
+          } as TEmitted);
+          return;
+        }
+
+        websocket.accept();
+
+        // Track snapshot state for applying patches
+        let currentSnapshot: CallerSnapshotFrom<TMachine> =
+          {} as CallerSnapshotFrom<TMachine>;
+
+        websocket.addEventListener("message", (event: MessageEvent) => {
+          try {
+            const data = JSON.parse(
+              typeof event.data === "string"
+                ? event.data
+                : new TextDecoder().decode(
+                    event.data as ArrayBuffer | Uint8Array
+                  )
+            ) as ActorKitEmittedEvent;
+
+            currentSnapshot = produce(currentSnapshot, (draft) => {
+              applyPatch(draft, data.operations);
+            });
+
+            sendBack({
+              type: `${ACTOR_TYPE_SNAKE}_UPDATED`,
+              actorType,
+              actorId: input.actorId,
+              snapshot: currentSnapshot,
+              operations: data.operations,
+            } as TEmitted);
+          } catch (err) {
+            console.error(
+              `[fromActorKit:${actorType}] Error processing message:`,
+              err
+            );
+          }
+        });
+
+        websocket.addEventListener("error", () => {
+          sendBack({
+            type: `${ACTOR_TYPE_SNAKE}_ERROR`,
+            actorType,
+            actorId: input.actorId,
+            error: new Error(
+              `WebSocket error for ${actorType}/${input.actorId}`
+            ),
+          } as TEmitted);
+        });
+
+        // Flush any events that were queued before WebSocket was ready
+        while (pendingEvents.length > 0) {
+          const queued = pendingEvents.shift()!;
+          websocket.send(queued);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error(`[fromActorKit:${actorType}] Setup error:`, error);
+        sendBack({
+          type: `${ACTOR_TYPE_SNAKE}_ERROR`,
+          actorType,
+          actorId: input.actorId,
+          error:
+            error instanceof Error
+              ? error
+              : new Error(`Setup failed for ${actorType}/${input.actorId}`),
+        } as TEmitted);
+      });
+
+    // Forward events from parent to remote DO
+    receive((event) => {
+      const parseResult = input.eventSchema.safeParse(event);
+      if (!parseResult.success) {
+        return; // Event doesn't match schema — not meant for this actor
+      }
+
+      const serialized = JSON.stringify(parseResult.data);
+      if (websocket) {
+        websocket.send(serialized);
+      } else {
+        // Queue for delivery when WebSocket is ready
+        pendingEvents.push(serialized);
+      }
+    });
+
+    // Cleanup on actor stop
+    return () => {
+      if (websocket) {
+        try {
+          websocket.close(1000, "Actor stopped");
+        } catch {
+          // Ignore close errors
+        }
+        websocket = null;
+      }
+    };
+  };
+
+  return fromCallback(callback);
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,2 +1,7 @@
 export { createActorKitRouter } from "./createActorKitRouter";
 export { createMachineServer } from "./createMachineServer";
+export { fromActorKit } from "./fromActorKit";
+export type {
+  FromActorKitEmitted,
+  FromActorKitInput,
+} from "./fromActorKit";

--- a/tests/integration/fixtures/from-actor-kit-worker.ts
+++ b/tests/integration/fixtures/from-actor-kit-worker.ts
@@ -1,0 +1,250 @@
+/**
+ * Test worker with two DOs: Counter and Aggregator.
+ * Aggregator uses fromActorKit to connect to Counter,
+ * demonstrating DO-to-DO communication.
+ */
+import type { DurableObjectNamespace } from "@cloudflare/workers-types";
+import type {
+  ActorKitSystemEvent,
+  AnyActorServer,
+  BaseActorKitEvent,
+  CallerSnapshotFrom,
+  WithActorKitEvent,
+  WithActorKitInput,
+} from "actor-kit";
+import {
+  createActorKitRouter,
+  createMachineServer,
+  fromActorKit,
+} from "actor-kit/worker";
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { assign, sendTo, setup } from "xstate";
+import { z } from "zod";
+
+// ============================================================================
+// Env
+// ============================================================================
+
+interface Env {
+  COUNTER: DurableObjectNamespace<InstanceType<typeof Counter>>;
+  AGGREGATOR: DurableObjectNamespace<InstanceType<typeof Aggregator>>;
+  ACTOR_KIT_SECRET: string;
+  [key: string]: DurableObjectNamespace<AnyActorServer> | unknown;
+}
+
+// ============================================================================
+// Counter DO (the "child" actor)
+// ============================================================================
+
+const CounterClientEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("INCREMENT") }),
+]);
+
+const CounterServiceEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("INCREMENT") }),
+]);
+
+const CounterInputPropsSchema = z.object({});
+
+type CounterClientEvent = z.infer<typeof CounterClientEventSchema>;
+type CounterServiceEvent = z.infer<typeof CounterServiceEventSchema>;
+
+type CounterEvent = (
+  | WithActorKitEvent<CounterClientEvent, "client">
+  | WithActorKitEvent<CounterServiceEvent, "service">
+  | ActorKitSystemEvent
+) &
+  BaseActorKitEvent<Env>;
+
+type CounterInput = WithActorKitInput<
+  z.infer<typeof CounterInputPropsSchema>,
+  Env
+>;
+
+type CounterServerContext = {
+  public: { count: number };
+  private: Record<string, never>;
+};
+
+const counterMachine = setup({
+  types: {
+    context: {} as CounterServerContext,
+    events: {} as CounterEvent,
+    input: {} as CounterInput,
+  },
+  actions: {
+    increment: assign({
+      public: ({ context }) => ({
+        count: context.public.count + 1,
+      }),
+    }),
+  },
+}).createMachine({
+  id: "counter",
+  initial: "active",
+  context: () => ({
+    public: { count: 0 },
+    private: {},
+  }),
+  states: {
+    active: {
+      on: {
+        INCREMENT: { actions: "increment" },
+      },
+    },
+  },
+});
+
+type CounterMachine = typeof counterMachine;
+
+export const Counter = createMachineServer({
+  machine: counterMachine,
+  schemas: {
+    clientEvent: CounterClientEventSchema,
+    serviceEvent: CounterServiceEventSchema,
+    inputProps: CounterInputPropsSchema,
+  },
+  options: { persisted: true },
+});
+
+// ============================================================================
+// Aggregator DO (connects to Counter via fromActorKit)
+// ============================================================================
+
+const AggregatorClientEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("INCREMENT_COUNTER") }),
+]);
+
+const AggregatorServiceEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("NOOP") }),
+]);
+
+const AggregatorInputPropsSchema = z.object({});
+
+type AggregatorClientEvent = z.infer<typeof AggregatorClientEventSchema>;
+type AggregatorServiceEvent = z.infer<typeof AggregatorServiceEventSchema>;
+
+type CounterUpdatedEvent = {
+  type: "COUNTER_UPDATED";
+  actorType: "counter";
+  actorId: string;
+  snapshot: CallerSnapshotFrom<CounterMachine>;
+  operations: unknown[];
+};
+
+type AggregatorEvent = (
+  | WithActorKitEvent<AggregatorClientEvent, "client">
+  | WithActorKitEvent<AggregatorServiceEvent, "service">
+  | ActorKitSystemEvent
+  | CounterUpdatedEvent
+) &
+  BaseActorKitEvent<Env>;
+
+type AggregatorInput = WithActorKitInput<
+  z.infer<typeof AggregatorInputPropsSchema>,
+  Env
+>;
+
+type AggregatorServerContext = {
+  public: {
+    counterCount: number;
+    counterId: string;
+  };
+  private: Record<string, never>;
+};
+
+const aggregatorMachine = setup({
+  types: {
+    context: {} as AggregatorServerContext,
+    events: {} as AggregatorEvent,
+    input: {} as AggregatorInput,
+  },
+  actors: {
+    counterConnection: fromActorKit<CounterMachine>("counter"),
+  },
+  actions: {
+    updateCounterSnapshot: assign({
+      public: ({ context, event }) => {
+        if (event.type !== "COUNTER_UPDATED") return context.public;
+        const snapshot = (event as CounterUpdatedEvent).snapshot as {
+          public: { count: number };
+        };
+        return {
+          ...context.public,
+          counterCount: snapshot.public.count,
+        };
+      },
+    }),
+    forwardIncrement: sendTo("counterConnection", { type: "INCREMENT" }),
+  },
+}).createMachine({
+  id: "aggregator",
+  initial: "active",
+  context: ({ input }) => ({
+    public: {
+      counterCount: 0,
+      // Deterministic counter ID based on aggregator ID
+      counterId: `counter-for-${input.id}`,
+    },
+    private: {},
+  }),
+  states: {
+    active: {
+      // Invoke the counter connection — runs for the lifetime of this state
+      invoke: {
+        id: "counterConnection",
+        src: "counterConnection",
+        // input function receives the xstate.init event with our actor input
+        input: ({ context, event }) => {
+          const machineInput = (event as unknown as { input: AggregatorInput })
+            .input;
+          return {
+            server: machineInput.env.COUNTER,
+            actorId: context.public.counterId,
+            actorInput: {},
+            caller: { id: "aggregator", type: "service" as const },
+            signingKey: machineInput.env.ACTOR_KIT_SECRET,
+            eventSchema: CounterServiceEventSchema,
+          };
+        },
+      },
+      on: {
+        COUNTER_UPDATED: {
+          actions: "updateCounterSnapshot",
+        },
+        INCREMENT_COUNTER: {
+          actions: "forwardIncrement",
+        },
+      },
+    },
+  },
+});
+
+export const Aggregator = createMachineServer({
+  machine: aggregatorMachine,
+  schemas: {
+    clientEvent: AggregatorClientEventSchema,
+    serviceEvent: AggregatorServiceEventSchema,
+    inputProps: AggregatorInputPropsSchema,
+  },
+  options: { persisted: true },
+});
+
+// ============================================================================
+// Worker
+// ============================================================================
+
+const router = createActorKitRouter<Env>(["counter", "aggregator"]);
+
+export default class Worker extends WorkerEntrypoint<Env> {
+  fetch(request: Request): Promise<Response> | Response {
+    const url = new URL(request.url);
+    if (url.pathname === "/health") {
+      return new Response("ok");
+    }
+    if (url.pathname.startsWith("/api/")) {
+      return router(request, this.env, this.ctx);
+    }
+    return new Response("Test worker", { status: 200 });
+  }
+}

--- a/tests/integration/fixtures/from-actor-kit-wrangler.toml
+++ b/tests/integration/fixtures/from-actor-kit-wrangler.toml
@@ -1,0 +1,18 @@
+name = "actor-kit-from-actor-kit-test"
+main = "from-actor-kit-worker.ts"
+compatibility_date = "2024-09-25"
+
+[vars]
+ACTOR_KIT_SECRET = "test-secret"
+
+[[durable_objects.bindings]]
+name = "COUNTER"
+class_name = "Counter"
+
+[[durable_objects.bindings]]
+name = "AGGREGATOR"
+class_name = "Aggregator"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["Counter", "Aggregator"]

--- a/tests/integration/from-actor-kit.test.ts
+++ b/tests/integration/from-actor-kit.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Integration test: fromActorKit — DO-to-DO communication
+ *
+ * Tests that an Aggregator DO can invoke a Counter DO via fromActorKit,
+ * receive snapshot updates, and forward events bidirectionally.
+ *
+ * Uses Miniflare with a pre-built worker fixture containing both DOs.
+ */
+import { Miniflare } from "miniflare";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createAccessToken } from "../../src/createAccessToken";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SECRET = "test-secret";
+
+type MfWebSocket = NonNullable<
+  Awaited<ReturnType<Miniflare["dispatchFetch"]>>["webSocket"]
+>;
+
+interface StateUpdateMessage {
+  operations: Array<{ op: string; path: string; value?: unknown }>;
+  checksum: string;
+}
+
+function parseMessage(data: string): StateUpdateMessage {
+  return JSON.parse(data) as StateUpdateMessage;
+}
+
+describe("fromActorKit: DO-to-DO communication", () => {
+  let mf: Miniflare;
+  let testCounter = 0;
+
+  function nextId(prefix = "test") {
+    return `${prefix}-${++testCounter}`;
+  }
+
+  beforeAll(async () => {
+    const scriptPath = path.resolve(
+      __dirname,
+      "fixtures/dist/from-actor-kit-worker.js"
+    );
+
+    mf = new Miniflare({
+      modules: true,
+      scriptPath,
+      durableObjects: {
+        COUNTER: "Counter",
+        AGGREGATOR: "Aggregator",
+      },
+      compatibilityDate: "2024-09-25",
+      compatibilityFlags: ["nodejs_compat"],
+      bindings: {
+        ACTOR_KIT_SECRET: SECRET,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await mf.dispose();
+  });
+
+  async function connectWebSocket(
+    actorType: string,
+    actorId: string,
+    userId: string
+  ): Promise<MfWebSocket> {
+    const token = await createAccessToken({
+      signingKey: SECRET,
+      actorId,
+      actorType,
+      callerId: userId,
+      callerType: "client",
+    });
+    const params = new URLSearchParams({ accessToken: token });
+    const url = `https://localhost/api/${actorType}/${actorId}?${params}`;
+    const res = await mf.dispatchFetch(url, {
+      headers: {
+        Upgrade: "websocket",
+        Connection: "Upgrade",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    expect(res.status).toBe(101);
+    const ws = res.webSocket!;
+    ws.accept();
+    return ws;
+  }
+
+  function collectMessages(ws: MfWebSocket) {
+    const messages: StateUpdateMessage[] = [];
+    ws.addEventListener("message", (event: { data: unknown }) => {
+      if (typeof event.data === "string") {
+        messages.push(parseMessage(event.data));
+      }
+    });
+    return messages;
+  }
+
+  async function waitForMessages(
+    messages: StateUpdateMessage[],
+    count: number,
+    timeoutMs = 3000
+  ) {
+    const start = Date.now();
+    while (messages.length < count && Date.now() - start < timeoutMs) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  }
+
+  function buildClientState(messages: StateUpdateMessage[]) {
+    const state: Record<string, unknown> = {};
+    for (const msg of messages) {
+      for (const op of msg.operations) {
+        if (
+          (op.op === "add" || op.op === "replace") &&
+          op.value !== undefined
+        ) {
+          const parts = op.path.split("/").filter(Boolean);
+          let target: Record<string, unknown> = state;
+          for (let i = 0; i < parts.length - 1; i++) {
+            if (
+              !(parts[i]! in target) ||
+              typeof target[parts[i]!] !== "object"
+            ) {
+              target[parts[i]!] = {};
+            }
+            target = target[parts[i]!] as Record<string, unknown>;
+          }
+          target[parts[parts.length - 1]!] = op.value;
+        }
+      }
+    }
+    return state as {
+      public?: Record<string, unknown>;
+      private?: Record<string, unknown>;
+      value?: unknown;
+    };
+  }
+
+  // --- Tests ---
+
+  it("aggregator receives counter updates via fromActorKit", async () => {
+    const aggregatorId = nextId("agg");
+
+    // Connect to aggregator — this should trigger it to connect to the counter
+    // via fromActorKit
+    const aggWs = await connectWebSocket("aggregator", aggregatorId, "user-1");
+    const aggMsgs = collectMessages(aggWs);
+    await waitForMessages(aggMsgs, 1);
+
+    // The aggregator should have an initial state
+    const initialState = buildClientState(aggMsgs);
+    expect(initialState.public).toBeDefined();
+
+    aggWs.close();
+  });
+
+  it("aggregator forwards INCREMENT to counter and receives updated count", async () => {
+    const aggregatorId = nextId("agg");
+
+    // Connect to aggregator
+    const aggWs = await connectWebSocket("aggregator", aggregatorId, "user-1");
+    const aggMsgs = collectMessages(aggWs);
+    await waitForMessages(aggMsgs, 1);
+
+    // Send INCREMENT_COUNTER to aggregator — it should forward to counter
+    aggWs.send(JSON.stringify({ type: "INCREMENT_COUNTER" }));
+
+    // Wait for the aggregator to receive the counter update
+    await waitForMessages(aggMsgs, 2, 5000);
+
+    // The aggregator's state should reflect the counter's count
+    const state = buildClientState(aggMsgs);
+    expect(state.public).toHaveProperty("counterCount");
+    expect((state.public as Record<string, unknown>).counterCount).toBe(1);
+
+    aggWs.close();
+  });
+
+  it("multiple increments flow through and accumulate", async () => {
+    const aggregatorId = nextId("agg");
+
+    const aggWs = await connectWebSocket("aggregator", aggregatorId, "user-1");
+    const aggMsgs = collectMessages(aggWs);
+    await waitForMessages(aggMsgs, 1);
+
+    // Send 3 increments
+    aggWs.send(JSON.stringify({ type: "INCREMENT_COUNTER" }));
+    aggWs.send(JSON.stringify({ type: "INCREMENT_COUNTER" }));
+    aggWs.send(JSON.stringify({ type: "INCREMENT_COUNTER" }));
+
+    // Wait for updates to propagate
+    await new Promise((r) => setTimeout(r, 2000));
+
+    const state = buildClientState(aggMsgs);
+    expect((state.public as Record<string, unknown>).counterCount).toBe(3);
+
+    aggWs.close();
+  });
+});


### PR DESCRIPTION
## Summary

Ports the `fromActorKit` pattern from Piqolo into actor-kit as a first-class export from `actor-kit/worker`. Creates an XState callback actor that connects to a remote actor-kit Durable Object via WebSocket.

**Features:**
- Auto JWT creation for remote actor auth
- WebSocket connection via DO stub.fetch()
- Snapshot patches applied and emitted as `{TYPE}_UPDATED` events
- Event forwarding with Zod schema validation
- Event queuing before WebSocket ready
- Cleanup on actor stop

**Integration test:** Aggregator DO invokes Counter DO via fromActorKit, forwards INCREMENT events, receives snapshot updates.

## Open questions
1. **Fixture build:** wrangler v4 `--outdir` with `--dry-run` no longer outputs bundles. Need proper build approach.
2. **`as unknown as` casts:** Need to update ActorServer for CF RPC types to avoid casts.
3. **`@cloudflare/workers-types` vs wrangler types:** Should we migrate?
4. **`nodejs_compat`:** Current esbuild fallback needs it; proper wrangler build shouldn't.

## Test plan
- [x] Integration tests pass (3 new: initial state, increment forwarding, accumulation)
- [ ] Fix fixture build tooling
- [ ] Remove nodejs_compat
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)