### PR TITLE
015: Pure transition() API for testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Run these in order before committing:
 
 1. `pnpm lint` — ESLint across src, tests, and examples
 2. `pnpm typecheck` — strict TypeScript compilation
-3. `pnpm test:unit` — Vitest unit tests (62 tests across 10 files)
+3. `pnpm test:unit` — Vitest unit tests (73 tests across 11 files)
 4. `pnpm test:coverage` — coverage report (thresholds: 10% lines, 5% branches)
 5. `pnpm test:mutate` — Stryker mutation testing (break threshold: 80%)
 

--- a/docs/roadmap/015-pure-transitions.md
+++ b/docs/roadmap/015-pure-transitions.md
@@ -1,7 +1,7 @@
 # 015: Pure Transition API for Testing
 
 **Priority**: P1
-**Status**: Proposal
+**Status**: Accepted (implemented 2026-03-19)
 **Inspired by**: `@xstate/store` v3 `store.transition(state, event)` API
 
 ## Problem

--- a/packages/actor-kit/src/test.ts
+++ b/packages/actor-kit/src/test.ts
@@ -1,1 +1,2 @@
 export { createActorKitMockClient } from "./createActorKitMockClient";
+export { transition } from "./transition";

--- a/packages/actor-kit/src/transition.ts
+++ b/packages/actor-kit/src/transition.ts
@@ -1,0 +1,146 @@
+import {
+  type AnyStateMachine,
+  type SnapshotFrom,
+  createActor,
+  type InputFrom,
+} from "xstate";
+import type {
+  AnyActorKitStateMachine,
+  CallerSnapshotFrom,
+  Caller,
+} from "./types";
+
+/**
+ * Mock storage that satisfies DurableObjectStorage interface for pure tests.
+ * All operations are no-ops — the transition is pure.
+ */
+const mockStorage = new Proxy(
+  {},
+  {
+    get: () => () => Promise.resolve(),
+  }
+) as DurableObjectStorage;
+
+/**
+ * Mock env that satisfies ActorKitEnv for pure tests.
+ */
+const mockEnv = new Proxy(
+  { ACTOR_KIT_SECRET: "test-secret" },
+  {
+    get: (target, prop) =>
+      prop in target
+        ? target[prop as keyof typeof target]
+        : undefined,
+  }
+);
+
+type TransitionOptions<TMachine extends AnyActorKitStateMachine> = {
+  /** Starting snapshot. If omitted, the machine starts from its initial state. */
+  snapshot?: SnapshotFrom<TMachine>;
+  /** The event to apply. */
+  event: { type: string; [key: string]: unknown };
+  /** The caller sending this event. */
+  caller: Caller;
+  /** Custom input props (passed to the machine's context factory). */
+  input?: Record<string, unknown>;
+};
+
+type TransitionResult<TMachine extends AnyActorKitStateMachine> = {
+  /** The raw XState snapshot — pass to the next transition() call to chain. */
+  snapshot: SnapshotFrom<TMachine>;
+  /** The full server context (public + all private). */
+  context: SnapshotFrom<TMachine> extends { context: infer C } ? C : unknown;
+  /** Caller-scoped snapshot (public + caller's private + state value). */
+  callerSnapshot: CallerSnapshotFrom<TMachine>;
+};
+
+/**
+ * Pure transition function for testing actor-kit state machines.
+ *
+ * Applies an event to a machine and returns the next state — no DO,
+ * no WebSocket, no storage required.
+ *
+ * ```ts
+ * const result = transition(machine, {
+ *   event: { type: 'INCREMENT' },
+ *   caller: { type: 'client', id: 'user-1' },
+ * });
+ * expect(result.context.public.count).toBe(1);
+ * ```
+ */
+export function transition<TMachine extends AnyActorKitStateMachine>(
+  machine: TMachine,
+  options: TransitionOptions<TMachine>
+): TransitionResult<TMachine> {
+  const { snapshot, event, caller, input: inputProps } = options;
+
+  // Augment event with caller, storage, env — same as createMachineServer.send()
+  const augmentedEvent = {
+    ...event,
+    caller,
+    storage: mockStorage,
+    env: mockEnv,
+  };
+
+  let nextSnapshot: SnapshotFrom<TMachine>;
+
+  if (snapshot) {
+    // Apply event to existing snapshot
+    const actor = createActor(machine as AnyStateMachine, {
+      snapshot: snapshot as SnapshotFrom<AnyStateMachine>,
+    });
+    actor.start();
+    actor.send(augmentedEvent);
+    nextSnapshot = actor.getSnapshot() as SnapshotFrom<TMachine>;
+    actor.stop();
+  } else {
+    // Create from initial state with input, apply event
+    const machineInput = {
+      id: "test-actor",
+      caller,
+      storage: mockStorage,
+      env: mockEnv,
+      ...(inputProps ?? {}),
+    } as InputFrom<TMachine>;
+
+    const actor = createActor(machine as AnyStateMachine, {
+      input: machineInput as InputFrom<AnyStateMachine>,
+    });
+    actor.start();
+    actor.send(augmentedEvent);
+    nextSnapshot = actor.getSnapshot() as SnapshotFrom<TMachine>;
+    actor.stop();
+  }
+
+  const context = (
+    nextSnapshot as unknown as { context: unknown }
+  ).context as TransitionResult<TMachine>["context"];
+
+  const callerSnapshot = createCallerSnapshot<TMachine>(
+    nextSnapshot,
+    caller.id
+  );
+
+  return { snapshot: nextSnapshot, context, callerSnapshot };
+}
+
+function createCallerSnapshot<TMachine extends AnyActorKitStateMachine>(
+  fullSnapshot: SnapshotFrom<TMachine>,
+  callerId: string
+): CallerSnapshotFrom<TMachine> {
+  const snap = fullSnapshot as unknown as {
+    value: unknown;
+    context: {
+      public: unknown;
+      private: Record<string, unknown>;
+    };
+  };
+
+  return {
+    public: snap.context.public,
+    private:
+      snap.context.private[callerId] ??
+      ({} as CallerSnapshotFrom<TMachine>["private"]),
+    value: snap.value,
+  } as CallerSnapshotFrom<TMachine>;
+}

--- a/packages/actor-kit/tests/transition.test.ts
+++ b/packages/actor-kit/tests/transition.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the pure transition() API.
+ *
+ * These test state transitions as pure functions — no DO, no WebSocket,
+ * no storage infrastructure required.
+ */
+import { describe, expect, it } from "vitest";
+import { assign, setup } from "xstate";
+import { transition } from "../src/transition";
+import type {
+  ActorKitSystemEvent,
+  BaseActorKitEvent,
+  WithActorKitEvent,
+  WithActorKitInput,
+} from "../src/types";
+
+// ---------------------------------------------------------------------------
+// Test machine: a simple counter with public/private context
+// ---------------------------------------------------------------------------
+
+interface CounterEnv {
+  ACTOR_KIT_SECRET: string;
+  [key: string]: unknown;
+}
+
+type CounterClientEvent =
+  | { type: "INCREMENT" }
+  | { type: "SET"; value: number };
+
+type CounterServiceEvent = { type: "RESET" };
+
+type CounterEvent = (
+  | WithActorKitEvent<CounterClientEvent, "client">
+  | WithActorKitEvent<CounterServiceEvent, "service">
+  | ActorKitSystemEvent
+) &
+  BaseActorKitEvent<CounterEnv>;
+
+type CounterInput = WithActorKitInput<
+  { initialCount?: number },
+  CounterEnv
+>;
+
+type CounterContext = {
+  public: { count: number; lastUpdatedBy: string | null };
+  private: Record<string, { accessCount: number }>;
+};
+
+const counterMachine = setup({
+  types: {
+    context: {} as CounterContext,
+    events: {} as CounterEvent,
+    input: {} as CounterInput,
+  },
+  actions: {
+    increment: assign({
+      public: ({ context, event }) => ({
+        ...context.public,
+        count: context.public.count + 1,
+        lastUpdatedBy: event.caller.id,
+      }),
+      private: ({ context, event }) => ({
+        ...context.private,
+        [event.caller.id]: {
+          accessCount:
+            (context.private[event.caller.id]?.accessCount ?? 0) + 1,
+        },
+      }),
+    }),
+    setValue: assign({
+      public: ({ context, event }) => {
+        if (event.type !== "SET") return context.public;
+        return {
+          ...context.public,
+          count: event.value,
+          lastUpdatedBy: event.caller.id,
+        };
+      },
+    }),
+    resetCounter: assign({
+      public: ({ context }) => ({
+        ...context.public,
+        count: 0,
+        lastUpdatedBy: null,
+      }),
+    }),
+  },
+}).createMachine({
+  id: "counter",
+  type: "parallel",
+  context: ({ input }: { input: CounterInput }) => ({
+    public: {
+      count: input.initialCount ?? 0,
+      lastUpdatedBy: null,
+    },
+    private: {},
+  }),
+  states: {
+    Operations: {
+      on: {
+        INCREMENT: { actions: ["increment"] },
+        SET: { actions: ["setValue"] },
+        RESET: { actions: ["resetCounter"] },
+      },
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("transition()", () => {
+  it("applies a client event and returns the next snapshot", () => {
+    const result = transition(counterMachine, {
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    expect(result.context.public.count).toBe(1);
+    expect(result.context.public.lastUpdatedBy).toBe("user-1");
+  });
+
+  it("provides a caller-scoped snapshot", () => {
+    const result = transition(counterMachine, {
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    expect(result.callerSnapshot.public.count).toBe(1);
+    expect(result.callerSnapshot.private.accessCount).toBe(1);
+    expect(result.callerSnapshot.value).toBeDefined();
+  });
+
+  it("returns only the caller's private context, not other callers", () => {
+    // First: user-1 increments
+    const after1 = transition(counterMachine, {
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    // Second: user-2 increments, starting from after1's snapshot
+    const after2 = transition(counterMachine, {
+      snapshot: after1.snapshot,
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-2" },
+    });
+
+    // user-2's caller snapshot should show user-2's private context
+    expect(after2.callerSnapshot.private.accessCount).toBe(1);
+    // Full context should show both callers
+    expect(after2.context.private["user-1"]?.accessCount).toBe(1);
+    expect(after2.context.private["user-2"]?.accessCount).toBe(1);
+    expect(after2.context.public.count).toBe(2);
+  });
+
+  it("accepts a service event", () => {
+    // Start with count=5
+    const initial = transition(counterMachine, {
+      event: { type: "SET", value: 5 },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    // Reset via service event
+    const result = transition(counterMachine, {
+      snapshot: initial.snapshot,
+      event: { type: "RESET" },
+      caller: { type: "service", id: "admin" },
+    });
+
+    expect(result.context.public.count).toBe(0);
+    expect(result.context.public.lastUpdatedBy).toBeNull();
+  });
+
+  it("starts from default context when no snapshot is provided", () => {
+    const result = transition(counterMachine, {
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    // Started from 0, incremented to 1
+    expect(result.context.public.count).toBe(1);
+  });
+
+  it("starts from a provided snapshot", () => {
+    // Build a snapshot with count=10
+    const base = transition(counterMachine, {
+      event: { type: "SET", value: 10 },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    // Increment from that snapshot
+    const result = transition(counterMachine, {
+      snapshot: base.snapshot,
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    expect(result.context.public.count).toBe(11);
+  });
+
+  it("provides mock env with ACTOR_KIT_SECRET", () => {
+    // The machine receives env via event augmentation.
+    // transition() should provide a mock env that satisfies ActorKitEnv.
+    // If the machine didn't throw, it means env was provided correctly.
+    const result = transition(counterMachine, {
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    expect(result.context.public.count).toBe(1);
+  });
+
+  it("accepts custom input props", () => {
+    const result = transition(counterMachine, {
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+      input: { initialCount: 100 },
+    });
+
+    expect(result.context.public.count).toBe(101);
+  });
+
+  it("returns the XState state value", () => {
+    const result = transition(counterMachine, {
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    expect(result.callerSnapshot.value).toEqual({ Operations: {} });
+  });
+
+  it("returns the raw XState snapshot for chaining", () => {
+    const first = transition(counterMachine, {
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    const second = transition(counterMachine, {
+      snapshot: first.snapshot,
+      event: { type: "INCREMENT" },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    expect(second.context.public.count).toBe(2);
+    expect(second.context.private["user-1"]?.accessCount).toBe(2);
+  });
+
+  it("provides empty private context for callers with no private data", () => {
+    const result = transition(counterMachine, {
+      event: { type: "SET", value: 42 },
+      caller: { type: "client", id: "user-1" },
+    });
+
+    // SET action doesn't write to private context, so user-1 has no entry
+    expect(result.callerSnapshot.private).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- Add `transition()` function to `actor-kit/test` for pure state transition testing
- No DO, WebSocket, or storage infrastructure required
- Augments events with mock env/storage automatically
- Returns full context + caller-scoped snapshot
- Supports snapshot chaining and custom input props

## Test plan
- [x] 11 new tests covering all scenarios from the proposal
- [ ] CI quality job passes
- [ ] CI e2e jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)