### PR TITLE
016: Framework-agnostic client selectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Run these in order before committing:
 
 1. `pnpm lint` — ESLint across src, tests, and examples
 2. `pnpm typecheck` — strict TypeScript compilation
-3. `pnpm test:unit` — Vitest unit tests (73 tests across 11 files)
+3. `pnpm test:unit` — Vitest unit tests (80 tests across 12 files)
 4. `pnpm test:coverage` — coverage report (thresholds: 10% lines, 5% branches)
 5. `pnpm test:mutate` — Stryker mutation testing (break threshold: 80%)
 

--- a/docs/roadmap/016-client-selectors.md
+++ b/docs/roadmap/016-client-selectors.md
@@ -1,7 +1,7 @@
 # 016: Framework-Agnostic Client Selectors
 
 **Priority**: P2
-**Status**: Proposal
+**Status**: Accepted (implemented 2026-03-19)
 **Inspired by**: `@xstate/store` v3 `store.select()` API
 
 ## Problem

--- a/packages/actor-kit/src/createActorKitClient.ts
+++ b/packages/actor-kit/src/createActorKitClient.ts
@@ -2,8 +2,10 @@ import { applyPatch } from "fast-json-patch";
 import { produce } from "immer";
 
 import { EmittedEventSchema } from "./schemas";
+import { createSelector } from "./selector";
 import type {
   ActorKitClient,
+  ActorKitSelector,
   AnyActorKitStateMachine,
   CallerSnapshotFrom,
   ClientEventFrom,
@@ -218,6 +220,12 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
     });
   };
 
+  const select = <TSelected>(
+    selectorFn: (state: CallerSnapshotFrom<TMachine>) => TSelected,
+    equalityFn?: (a: TSelected, b: TSelected) => boolean
+  ): ActorKitSelector<TSelected> =>
+    createSelector(getState, subscribe, selectorFn, equalityFn);
+
   return {
     connect,
     disconnect,
@@ -225,6 +233,7 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
     getState,
     subscribe,
     waitFor,
+    select,
   };
 }
 

--- a/packages/actor-kit/src/createActorKitMockClient.ts
+++ b/packages/actor-kit/src/createActorKitMockClient.ts
@@ -1,6 +1,8 @@
 import { Draft, produce } from "immer";
+import { createSelector } from "./selector";
 import {
   ActorKitClient,
+  ActorKitSelector,
   AnyActorKitStateMachine,
   CallerSnapshotFrom,
   ClientEventFrom,
@@ -126,6 +128,12 @@ export function createActorKitMockClient<TMachine extends AnyActorKitStateMachin
     });
   };
 
+  const select = <TSelected>(
+    selectorFn: (state: CallerSnapshotFrom<TMachine>) => TSelected,
+    equalityFn?: (a: TSelected, b: TSelected) => boolean
+  ): ActorKitSelector<TSelected> =>
+    createSelector(getState, subscribe, selectorFn, equalityFn);
+
   return {
     connect,
     disconnect,
@@ -134,5 +142,6 @@ export function createActorKitMockClient<TMachine extends AnyActorKitStateMachin
     subscribe,
     produce: produceFn,
     waitFor,
+    select,
   };
 }

--- a/packages/actor-kit/src/selector.ts
+++ b/packages/actor-kit/src/selector.ts
@@ -1,0 +1,72 @@
+/**
+ * Framework-agnostic selector for ActorKitClient.
+ *
+ * Subscribes to client state internally, compares selected value on
+ * each update, and only notifies subscribers when it actually changes.
+ */
+export type ActorKitSelector<T> = {
+  /** Get the current selected value. */
+  get(): T;
+  /** Subscribe — only fires when the selected value changes. Returns unsubscribe function. */
+  subscribe(listener: (value: T) => void): () => void;
+};
+
+/**
+ * Creates a selector that derives a value from client state.
+ *
+ * @param getState - Returns the current full snapshot
+ * @param subscribeToClient - Subscribes to all state changes on the client
+ * @param selectorFn - Extracts the desired slice from the snapshot
+ * @param equalityFn - Optional custom equality (default: Object.is)
+ */
+export function createSelector<TSnapshot, TSelected>(
+  getState: () => TSnapshot,
+  subscribeToClient: (listener: (state: TSnapshot) => void) => () => void,
+  selectorFn: (state: TSnapshot) => TSelected,
+  equalityFn: (a: TSelected, b: TSelected) => boolean = Object.is
+): ActorKitSelector<TSelected> {
+  let currentValue = selectorFn(getState());
+  const listeners = new Set<(value: TSelected) => void>();
+
+  // Subscribe to the client once — shared across all selector subscribers
+  let clientUnsub: (() => void) | null = null;
+  let refCount = 0;
+
+  function ensureSubscribed() {
+    if (clientUnsub) return;
+    clientUnsub = subscribeToClient((state) => {
+      const nextValue = selectorFn(state);
+      if (!equalityFn(currentValue, nextValue)) {
+        currentValue = nextValue;
+        listeners.forEach((l) => l(currentValue));
+      }
+    });
+  }
+
+  function maybeUnsubscribe() {
+    if (refCount === 0 && clientUnsub) {
+      clientUnsub();
+      clientUnsub = null;
+    }
+  }
+
+  return {
+    get() {
+      // Always recompute from current state to stay fresh
+      currentValue = selectorFn(getState());
+      return currentValue;
+    },
+
+    subscribe(listener: (value: TSelected) => void) {
+      listeners.add(listener);
+      refCount++;
+      ensureSubscribed();
+
+      return () => {
+        listeners.delete(listener);
+        refCount--;
+        maybeUnsubscribe();
+      };
+    },
+  };
+}

--- a/packages/actor-kit/src/types.ts
+++ b/packages/actor-kit/src/types.ts
@@ -282,6 +282,11 @@ export type ActorKitEmittedEvent = {
   checksum: string;
 };
 
+export type ActorKitSelector<T> = {
+  get(): T;
+  subscribe(listener: (value: T) => void): () => void;
+};
+
 export type ActorKitClient<TMachine extends AnyActorKitStateMachine> = {
   connect: () => Promise<void>;
   disconnect: () => void;
@@ -294,6 +299,10 @@ export type ActorKitClient<TMachine extends AnyActorKitStateMachine> = {
     predicateFn: (state: CallerSnapshotFrom<TMachine>) => boolean,
     timeoutMs?: number
   ) => Promise<void>;
+  select: <TSelected>(
+    selector: (state: CallerSnapshotFrom<TMachine>) => TSelected,
+    equalityFn?: (a: TSelected, b: TSelected) => boolean
+  ) => ActorKitSelector<TSelected>;
 };
 
 // First define a helper to extract the event type from a machine

--- a/packages/actor-kit/tests/selector.test.ts
+++ b/packages/actor-kit/tests/selector.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for client.select() — framework-agnostic selectors.
+ *
+ * Selectors subscribe to client state internally and only notify
+ * their own subscribers when the selected value changes.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createActorKitClient } from "../src/createActorKitClient";
+
+// ---------------------------------------------------------------------------
+// Minimal machine type for selector tests
+// ---------------------------------------------------------------------------
+
+type TestSnapshot = {
+  value: "active";
+  public: { count: number; name: string };
+  private: Record<string, never>;
+};
+
+type TestMachine = {
+  input: unknown;
+  context: unknown;
+  events: { type: "INCREMENT" } | { type: "SET_NAME"; name: string };
+  value: "active";
+  output: unknown;
+  transition: unknown;
+  config: unknown;
+};
+
+// ---------------------------------------------------------------------------
+// MockWebSocket (same pattern as create-actor-kit-client.test.ts)
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+  private listeners = new Map<string, Array<(event?: unknown) => void>>();
+
+  constructor() {
+    MockWebSocket.instances.push(this);
+  }
+
+  static reset() {
+    MockWebSocket.instances = [];
+  }
+
+  addEventListener(type: string, listener: (event?: unknown) => void) {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  send(payload: string) {
+    this.sent.push(payload);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit("close");
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.emit("open");
+  }
+
+  emitMessage(data: unknown) {
+    this.emit("message", { data });
+  }
+
+  emit(type: string, event?: unknown) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const initialSnapshot: TestSnapshot = {
+  value: "active",
+  public: { count: 0, name: "Alice" },
+  private: {},
+};
+
+function patchMessage(
+  ops: Array<{ op: string; path: string; value?: unknown }>,
+  checksum: string
+) {
+  return JSON.stringify({ operations: ops, checksum });
+}
+
+function createTestClient() {
+  const client = createActorKitClient<TestMachine>({
+    host: "localhost:8788",
+    actorType: "test",
+    actorId: "test-1",
+    checksum: "abc123",
+    accessToken: "token",
+    initialSnapshot,
+  });
+  return client;
+}
+
+function getLatestMockWs() {
+  return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let originalWebSocket: typeof WebSocket;
+
+beforeEach(() => {
+  MockWebSocket.reset();
+  originalWebSocket = globalThis.WebSocket;
+  globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("client.select()", () => {
+  it("returns current selected value via .get()", () => {
+    const client = createTestClient();
+
+    const count = client.select((s) => s.public.count);
+    expect(count.get()).toBe(0);
+  });
+
+  it("updates .get() when underlying state changes", async () => {
+    const client = createTestClient();
+    const count = client.select((s) => s.public.count);
+
+    // Connect and open WebSocket
+    const connectPromise = client.connect();
+    const ws = getLatestMockWs();
+    ws.open();
+    await connectPromise;
+
+    // Simulate a state update via server message
+    ws.emitMessage(
+      patchMessage(
+        [{ op: "replace", path: "/public/count", value: 5 }],
+        "check2"
+      )
+    );
+
+    expect(count.get()).toBe(5);
+    client.disconnect();
+  });
+
+  it("only notifies subscribers when selected value changes", async () => {
+    const client = createTestClient();
+    const count = client.select((s) => s.public.count);
+    const listener = vi.fn();
+    count.subscribe(listener);
+
+    const connectPromise = client.connect();
+    const ws = getLatestMockWs();
+    ws.open();
+    await connectPromise;
+
+    // Change name (not count) — selector should NOT fire
+    ws.emitMessage(
+      patchMessage(
+        [{ op: "replace", path: "/public/name", value: "Bob" }],
+        "check2"
+      )
+    );
+    expect(listener).not.toHaveBeenCalled();
+
+    // Change count — selector SHOULD fire
+    ws.emitMessage(
+      patchMessage(
+        [{ op: "replace", path: "/public/count", value: 1 }],
+        "check3"
+      )
+    );
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(1);
+
+    client.disconnect();
+  });
+
+  it("supports custom equality function", async () => {
+    const client = createTestClient();
+
+    // Select an object slice with custom shallow equality
+    const stats = client.select(
+      (s) => ({ count: s.public.count, name: s.public.name }),
+      (a, b) => a.count === b.count && a.name === b.name
+    );
+
+    const listener = vi.fn();
+    stats.subscribe(listener);
+
+    const connectPromise = client.connect();
+    const ws = getLatestMockWs();
+    ws.open();
+    await connectPromise;
+
+    // Same values, different part of state changed — should NOT fire
+    ws.emitMessage(
+      patchMessage(
+        [{ op: "replace", path: "/value", value: "still-active" }],
+        "check2"
+      )
+    );
+    expect(listener).not.toHaveBeenCalled();
+
+    // Different count — SHOULD fire
+    ws.emitMessage(
+      patchMessage(
+        [{ op: "replace", path: "/public/count", value: 10 }],
+        "check3"
+      )
+    );
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ count: 10, name: "Alice" });
+
+    client.disconnect();
+  });
+
+  it("multiple selectors on same client are independent", async () => {
+    const client = createTestClient();
+
+    const countListener = vi.fn();
+    const nameListener = vi.fn();
+
+    client.select((s) => s.public.count).subscribe(countListener);
+    client.select((s) => s.public.name).subscribe(nameListener);
+
+    const connectPromise = client.connect();
+    const ws = getLatestMockWs();
+    ws.open();
+    await connectPromise;
+
+    // Change count only
+    ws.emitMessage(
+      patchMessage(
+        [{ op: "replace", path: "/public/count", value: 1 }],
+        "check2"
+      )
+    );
+
+    expect(countListener).toHaveBeenCalledTimes(1);
+    expect(nameListener).not.toHaveBeenCalled();
+
+    client.disconnect();
+  });
+
+  it("unsubscribe cleans up the listener", async () => {
+    const client = createTestClient();
+    const count = client.select((s) => s.public.count);
+    const listener = vi.fn();
+    const unsub = count.subscribe(listener);
+
+    const connectPromise = client.connect();
+    const ws = getLatestMockWs();
+    ws.open();
+    await connectPromise;
+
+    // Fire once
+    ws.emitMessage(
+      patchMessage(
+        [{ op: "replace", path: "/public/count", value: 1 }],
+        "check2"
+      )
+    );
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Unsubscribe
+    unsub();
+
+    // Should not fire again
+    ws.emitMessage(
+      patchMessage(
+        [{ op: "replace", path: "/public/count", value: 2 }],
+        "check3"
+      )
+    );
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    client.disconnect();
+  });
+
+  it("selector works before connect (uses initial snapshot)", () => {
+    const client = createTestClient();
+
+    const name = client.select((s) => s.public.name);
+    expect(name.get()).toBe("Alice");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `client.select(selector, equalityFn?)` to ActorKitClient
- New `src/selector.ts` with `createSelector()` core logic
- Selectors only notify when the selected value changes (via equality check)
- Works on both real client and mock client
- Default equality: `Object.is`; custom equality supported

## Test plan
- [x] 7 new tests for selector behavior
- [ ] CI quality job passes
- [ ] CI e2e jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)