### PR TITLE
017: Typed trigger API for client events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Run these in order before committing:
 
 1. `pnpm lint` — ESLint across src, tests, and examples
 2. `pnpm typecheck` — strict TypeScript compilation
-3. `pnpm test:unit` — Vitest unit tests (80 tests across 12 files)
+3. `pnpm test:unit` — Vitest unit tests (85 tests across 13 files)
 4. `pnpm test:coverage` — coverage report (thresholds: 10% lines, 5% branches)
 5. `pnpm test:mutate` — Stryker mutation testing (break threshold: 80%)
 

--- a/docs/roadmap/017-trigger-api.md
+++ b/docs/roadmap/017-trigger-api.md
@@ -1,7 +1,7 @@
 # 017: Typed Trigger API for Client Events
 
 **Priority**: P3
-**Status**: Proposal
+**Status**: Accepted (implemented 2026-03-19)
 **Inspired by**: `@xstate/store` v3 `store.trigger.eventName()` API
 
 ## Problem

--- a/packages/actor-kit/src/createActorKitClient.ts
+++ b/packages/actor-kit/src/createActorKitClient.ts
@@ -220,6 +220,14 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
     });
   };
 
+  const trigger = new Proxy({} as ActorKitClient<TMachine>["trigger"], {
+    get(_target, eventType: string) {
+      return (payload?: Record<string, unknown>) => {
+        send({ type: eventType, ...payload } as ClientEventFrom<TMachine>);
+      };
+    },
+  });
+
   const select = <TSelected>(
     selectorFn: (state: CallerSnapshotFrom<TMachine>) => TSelected,
     equalityFn?: (a: TSelected, b: TSelected) => boolean
@@ -234,6 +242,7 @@ export function createActorKitClient<TMachine extends AnyActorKitStateMachine>(
     subscribe,
     waitFor,
     select,
+    trigger,
   };
 }
 

--- a/packages/actor-kit/src/createActorKitMockClient.ts
+++ b/packages/actor-kit/src/createActorKitMockClient.ts
@@ -128,6 +128,14 @@ export function createActorKitMockClient<TMachine extends AnyActorKitStateMachin
     });
   };
 
+  const trigger = new Proxy({} as ActorKitMockClient<TMachine>["trigger"], {
+    get(_target, eventType: string) {
+      return (payload?: Record<string, unknown>) => {
+        send({ type: eventType, ...payload } as ClientEventFrom<TMachine>);
+      };
+    },
+  });
+
   const select = <TSelected>(
     selectorFn: (state: CallerSnapshotFrom<TMachine>) => TSelected,
     equalityFn?: (a: TSelected, b: TSelected) => boolean
@@ -143,5 +151,6 @@ export function createActorKitMockClient<TMachine extends AnyActorKitStateMachin
     produce: produceFn,
     waitFor,
     select,
+    trigger,
   };
 }

--- a/packages/actor-kit/src/types.ts
+++ b/packages/actor-kit/src/types.ts
@@ -287,6 +287,17 @@ export type ActorKitSelector<T> = {
   subscribe(listener: (value: T) => void): () => void;
 };
 
+/**
+ * Maps a union of event objects into a trigger API:
+ *   { type: "FOO"; x: number } | { type: "BAR" }
+ *   →  { FOO(payload: { x: number }): void; BAR(): void }
+ */
+export type TriggerAPI<TEvent extends { type: string }> = {
+  [K in TEvent["type"]]: Omit<Extract<TEvent, { type: K }>, "type"> extends Record<string, never>
+    ? () => void
+    : (payload: Omit<Extract<TEvent, { type: K }>, "type">) => void;
+};
+
 export type ActorKitClient<TMachine extends AnyActorKitStateMachine> = {
   connect: () => Promise<void>;
   disconnect: () => void;
@@ -303,6 +314,7 @@ export type ActorKitClient<TMachine extends AnyActorKitStateMachine> = {
     selector: (state: CallerSnapshotFrom<TMachine>) => TSelected,
     equalityFn?: (a: TSelected, b: TSelected) => boolean
   ) => ActorKitSelector<TSelected>;
+  trigger: TriggerAPI<ClientEventFrom<TMachine>>;
 };
 
 // First define a helper to extract the event type from a machine

--- a/packages/actor-kit/tests/trigger.test.ts
+++ b/packages/actor-kit/tests/trigger.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for client.trigger — typed event dispatch.
+ *
+ * trigger.EVENT_NAME(payload) is syntactic sugar for
+ * send({ type: 'EVENT_NAME', ...payload }).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createActorKitClient } from "../src/createActorKitClient";
+import { createActorKitMockClient } from "../src/createActorKitMockClient";
+
+// ---------------------------------------------------------------------------
+// Minimal machine type with multiple event types
+// ---------------------------------------------------------------------------
+
+type TodoClientEvent =
+  | { type: "ADD_TODO"; text: string }
+  | { type: "TOGGLE_TODO"; id: string }
+  | { type: "CLEAR_COMPLETED" };
+
+type TodoSnapshot = {
+  value: "ready";
+  public: {
+    todos: Array<{ id: string; text: string; done: boolean }>;
+  };
+  private: Record<string, never>;
+};
+
+type TodoMachine = {
+  input: unknown;
+  context: unknown;
+  events: TodoClientEvent;
+  value: "ready";
+  output: unknown;
+  transition: unknown;
+  config: unknown;
+};
+
+// ---------------------------------------------------------------------------
+// MockWebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+  private listeners = new Map<string, Array<(event?: unknown) => void>>();
+
+  constructor() {
+    MockWebSocket.instances.push(this);
+  }
+
+  static reset() {
+    MockWebSocket.instances = [];
+  }
+
+  addEventListener(type: string, listener: (event?: unknown) => void) {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  send(payload: string) {
+    this.sent.push(payload);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit("close");
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.emit("open");
+  }
+
+  emit(type: string, event?: unknown) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const initialSnapshot: TodoSnapshot = {
+  value: "ready",
+  public: { todos: [] },
+  private: {},
+};
+
+let originalWebSocket: typeof WebSocket;
+
+beforeEach(() => {
+  MockWebSocket.reset();
+  originalWebSocket = globalThis.WebSocket;
+  globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("client.trigger", () => {
+  it("sends correct event with payload", async () => {
+    const client = createActorKitClient<TodoMachine>({
+      host: "localhost:8788",
+      actorType: "todo",
+      actorId: "todo-1",
+      checksum: "abc",
+      accessToken: "token",
+      initialSnapshot,
+    });
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await connectPromise;
+
+    client.trigger.ADD_TODO({ text: "Buy milk" });
+
+    expect(ws.sent).toHaveLength(1);
+    expect(JSON.parse(ws.sent[0])).toEqual({
+      type: "ADD_TODO",
+      text: "Buy milk",
+    });
+
+    client.disconnect();
+  });
+
+  it("sends event with no payload", async () => {
+    const client = createActorKitClient<TodoMachine>({
+      host: "localhost:8788",
+      actorType: "todo",
+      actorId: "todo-1",
+      checksum: "abc",
+      accessToken: "token",
+      initialSnapshot,
+    });
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await connectPromise;
+
+    client.trigger.CLEAR_COMPLETED();
+
+    expect(ws.sent).toHaveLength(1);
+    expect(JSON.parse(ws.sent[0])).toEqual({ type: "CLEAR_COMPLETED" });
+
+    client.disconnect();
+  });
+
+  it("queues triggers before connection (like send)", () => {
+    const client = createActorKitClient<TodoMachine>({
+      host: "localhost:8788",
+      actorType: "todo",
+      actorId: "todo-1",
+      checksum: "abc",
+      accessToken: "token",
+      initialSnapshot,
+    });
+
+    // Trigger before connecting — should queue
+    client.trigger.ADD_TODO({ text: "Queued item" });
+
+    // No WebSocket yet, nothing sent
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
+  it("works on mock client", () => {
+    const onSend = vi.fn();
+    const mockClient = createActorKitMockClient<TodoMachine>({
+      initialSnapshot,
+      onSend,
+    });
+
+    mockClient.trigger.TOGGLE_TODO({ id: "abc" });
+
+    expect(onSend).toHaveBeenCalledWith({ type: "TOGGLE_TODO", id: "abc" });
+  });
+
+  it("is equivalent to send()", async () => {
+    const client = createActorKitClient<TodoMachine>({
+      host: "localhost:8788",
+      actorType: "todo",
+      actorId: "todo-1",
+      checksum: "abc",
+      accessToken: "token",
+      initialSnapshot,
+    });
+
+    const connectPromise = client.connect();
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await connectPromise;
+
+    client.trigger.ADD_TODO({ text: "Via trigger" });
+    client.send({ type: "ADD_TODO", text: "Via send" });
+
+    expect(JSON.parse(ws.sent[0])).toEqual({
+      type: "ADD_TODO",
+      text: "Via trigger",
+    });
+    expect(JSON.parse(ws.sent[1])).toEqual({
+      type: "ADD_TODO",
+      text: "Via send",
+    });
+
+    client.disconnect();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `client.trigger.EVENT_NAME(payload)` proxy for typed event dispatch
- Proxy-based implementation using `TriggerAPI<TEvent>` mapped type
- Works on both real client and mock client
- `send()` API unchanged — trigger is syntactic sugar

## Test plan
- [x] 5 new tests covering payload, no-payload, queueing, mock, equivalence
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)