### PR TITLE
011: Machine-running mock client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Run these in order before committing:
 
 1. `pnpm lint` — ESLint across src, tests, and examples
 2. `pnpm typecheck` — strict TypeScript compilation
-3. `pnpm test:unit` — Vitest unit tests (85 tests across 13 files)
+3. `pnpm test:unit` — Vitest unit tests (96 tests across 14 files)
 4. `pnpm test:coverage` — coverage report (thresholds: 10% lines, 5% branches)
 5. `pnpm test:mutate` — Stryker mutation testing (break threshold: 80%)
 

--- a/docs/roadmap/011-machine-mock-client.md
+++ b/docs/roadmap/011-machine-mock-client.md
@@ -1,7 +1,7 @@
 # 011: Machine-Running Mock Client
 
 **Priority**: P3
-**Status**: Proposal
+**Status**: Accepted (implemented 2026-03-19)
 **Affects**: `createActorKitMockClient.ts`
 
 ## Problem

--- a/packages/actor-kit/src/createActorKitMachineClient.ts
+++ b/packages/actor-kit/src/createActorKitMachineClient.ts
@@ -1,0 +1,182 @@
+import {
+  type AnyStateMachine,
+  type InputFrom,
+  createActor,
+} from "xstate";
+import { createSelector } from "./selector";
+import type {
+  ActorKitClient,
+  ActorKitSelector,
+  AnyActorKitStateMachine,
+  Caller,
+  CallerSnapshotFrom,
+  ClientEventFrom,
+} from "./types";
+
+export type ActorKitMachineClientOptions<
+  TMachine extends AnyActorKitStateMachine,
+> = {
+  /** The XState machine definition. */
+  machine: TMachine;
+  /** The caller identity for event augmentation. */
+  caller: Caller;
+  /** Optional input props (merged with default mock input). */
+  input?: Record<string, unknown>;
+};
+
+/**
+ * Mock storage for the machine client — all operations are no-ops.
+ */
+const mockStorage = new Proxy(
+  {},
+  { get: () => () => Promise.resolve() }
+) as DurableObjectStorage;
+
+/**
+ * Mock env for the machine client.
+ */
+const mockEnv = new Proxy(
+  { ACTOR_KIT_SECRET: "test-secret" },
+  {
+    get: (target, prop) =>
+      prop in target
+        ? target[prop as keyof typeof target]
+        : undefined,
+  }
+);
+
+/**
+ * Creates a mock client backed by a real running XState actor.
+ *
+ * Unlike `createActorKitMockClient` (snapshot-only), this client starts the
+ * machine so guards, actions, and invoked actors actually execute. Useful for
+ * Storybook stories and integration tests that need real machine behavior.
+ */
+export function createActorKitMachineClient<
+  TMachine extends AnyActorKitStateMachine,
+>(
+  options: ActorKitMachineClientOptions<TMachine>
+): ActorKitClient<TMachine> {
+  const { machine, caller, input: inputProps } = options;
+
+  const machineInput = {
+    id: "mock-actor",
+    caller,
+    storage: mockStorage,
+    env: mockEnv,
+    ...(inputProps ?? {}),
+  } as InputFrom<TMachine>;
+
+  const actor = createActor(machine as AnyStateMachine, {
+    input: machineInput as InputFrom<AnyStateMachine>,
+  });
+  actor.start();
+
+  const listeners = new Set<
+    (state: CallerSnapshotFrom<TMachine>) => void
+  >();
+
+  // Subscribe to XState actor, forward to listeners
+  actor.subscribe(() => {
+    const callerSnapshot = getCallerSnapshot();
+    listeners.forEach((l) => l(callerSnapshot));
+  });
+
+  function getCallerSnapshot(): CallerSnapshotFrom<TMachine> {
+    const fullSnapshot = actor.getSnapshot() as unknown as {
+      value: unknown;
+      context: {
+        public: unknown;
+        private: Record<string, unknown>;
+      };
+    };
+    return {
+      public: fullSnapshot.context.public,
+      private:
+        fullSnapshot.context.private[caller.id] ??
+        ({} as CallerSnapshotFrom<TMachine>["private"]),
+      value: fullSnapshot.value,
+    } as CallerSnapshotFrom<TMachine>;
+  }
+
+  const send = (event: ClientEventFrom<TMachine>) => {
+    // Augment event with caller, storage, env — same as createMachineServer
+    actor.send({
+      ...event,
+      caller,
+      storage: mockStorage,
+      env: mockEnv,
+    } as unknown as Parameters<typeof actor.send>[0]);
+  };
+
+  const getState = () => getCallerSnapshot();
+
+  const subscribe = (
+    listener: (state: CallerSnapshotFrom<TMachine>) => void
+  ) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const connect = async () => {
+    // No-op for machine client
+  };
+
+  const disconnect = () => {
+    // No-op for machine client
+  };
+
+  const waitFor = async (
+    predicateFn: (state: CallerSnapshotFrom<TMachine>) => boolean,
+    timeoutMs: number = 5000
+  ): Promise<void> => {
+    if (predicateFn(getCallerSnapshot())) {
+      return;
+    }
+    return new Promise((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      if (timeoutMs > 0) {
+        timeoutId = setTimeout(() => {
+          unsub();
+          reject(
+            new Error(`Timeout waiting for condition after ${timeoutMs}ms`)
+          );
+        }, timeoutMs);
+      }
+      const unsub = subscribe((state) => {
+        if (predicateFn(state)) {
+          if (timeoutId) clearTimeout(timeoutId);
+          unsub();
+          resolve();
+        }
+      });
+    });
+  };
+
+  const select = <TSelected>(
+    selectorFn: (state: CallerSnapshotFrom<TMachine>) => TSelected,
+    equalityFn?: (a: TSelected, b: TSelected) => boolean
+  ): ActorKitSelector<TSelected> =>
+    createSelector(getState, subscribe, selectorFn, equalityFn);
+
+  const trigger = new Proxy({} as ActorKitClient<TMachine>["trigger"], {
+    get(_target, eventType: string) {
+      return (payload?: Record<string, unknown>) => {
+        send({ type: eventType, ...payload } as ClientEventFrom<TMachine>);
+      };
+    },
+  });
+
+  return {
+    connect,
+    disconnect,
+    send,
+    getState,
+    subscribe,
+    waitFor,
+    select,
+    trigger,
+  };
+}

--- a/packages/actor-kit/src/test.ts
+++ b/packages/actor-kit/src/test.ts
@@ -1,2 +1,3 @@
 export { createActorKitMockClient } from "./createActorKitMockClient";
+export { createActorKitMachineClient } from "./createActorKitMachineClient";
 export { transition } from "./transition";

--- a/packages/actor-kit/tests/machine-client.test.ts
+++ b/packages/actor-kit/tests/machine-client.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for createActorKitMachineClient — a mock client that runs the real machine.
+ *
+ * Unlike createActorKitMockClient (snapshot-only), this client starts an XState
+ * actor so guards, actions, and invoked actors actually execute.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { assign, setup } from "xstate";
+import { createActorKitMachineClient } from "../src/createActorKitMachineClient";
+import type {
+  ActorKitSystemEvent,
+  BaseActorKitEvent,
+  WithActorKitEvent,
+  WithActorKitInput,
+} from "../src/types";
+
+// ---------------------------------------------------------------------------
+// Test machine: counter with a guard
+// ---------------------------------------------------------------------------
+
+interface TestEnv {
+  ACTOR_KIT_SECRET: string;
+  [key: string]: unknown;
+}
+
+type CounterClientEvent =
+  | { type: "INCREMENT" }
+  | { type: "SET"; value: number }
+  | { type: "ADMIN_RESET" };
+
+type CounterServiceEvent = { type: "NOOP" };
+
+type CounterEvent = (
+  | WithActorKitEvent<CounterClientEvent, "client">
+  | WithActorKitEvent<CounterServiceEvent, "service">
+  | ActorKitSystemEvent
+) &
+  BaseActorKitEvent<TestEnv>;
+
+type CounterInput = WithActorKitInput<
+  { initialCount?: number },
+  TestEnv
+>;
+
+type CounterContext = {
+  public: { count: number; lastUpdatedBy: string | null };
+  private: Record<string, { accessCount: number }>;
+};
+
+const counterMachine = setup({
+  types: {
+    context: {} as CounterContext,
+    events: {} as CounterEvent,
+    input: {} as CounterInput,
+  },
+  guards: {
+    isAdmin: ({ event }) => event.caller.id === "admin",
+  },
+  actions: {
+    increment: assign({
+      public: ({ context, event }) => ({
+        ...context.public,
+        count: context.public.count + 1,
+        lastUpdatedBy: event.caller.id,
+      }),
+      private: ({ context, event }) => ({
+        ...context.private,
+        [event.caller.id]: {
+          accessCount:
+            (context.private[event.caller.id]?.accessCount ?? 0) + 1,
+        },
+      }),
+    }),
+    resetCounter: assign({
+      public: ({ context }) => ({
+        ...context.public,
+        count: 0,
+        lastUpdatedBy: null,
+      }),
+    }),
+    setValue: assign({
+      public: ({ context, event }) => {
+        if (event.type !== "SET") return context.public;
+        return {
+          ...context.public,
+          count: event.value,
+          lastUpdatedBy: event.caller.id,
+        };
+      },
+    }),
+  },
+}).createMachine({
+  id: "counter",
+  type: "parallel",
+  context: ({ input }: { input: CounterInput }) => ({
+    public: {
+      count: input.initialCount ?? 0,
+      lastUpdatedBy: null,
+    },
+    private: {},
+  }),
+  states: {
+    Operations: {
+      on: {
+        INCREMENT: { actions: ["increment"] },
+        SET: { actions: ["setValue"] },
+        ADMIN_RESET: {
+          guard: "isAdmin",
+          actions: ["resetCounter"],
+        },
+      },
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createActorKitMachineClient", () => {
+  it("runs the real machine: send() triggers actions", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    client.send({ type: "INCREMENT" });
+
+    expect(client.getState().public.count).toBe(1);
+    expect(client.getState().public.lastUpdatedBy).toBe("user-1");
+  });
+
+  it("evaluates guards: non-admin cannot reset", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    client.send({ type: "SET", value: 10 });
+    expect(client.getState().public.count).toBe(10);
+
+    // Non-admin tries to reset — guard should reject
+    client.send({ type: "ADMIN_RESET" });
+    expect(client.getState().public.count).toBe(10);
+  });
+
+  it("evaluates guards: admin can reset", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "admin" },
+    });
+
+    client.send({ type: "SET", value: 10 });
+    client.send({ type: "ADMIN_RESET" });
+    expect(client.getState().public.count).toBe(0);
+  });
+
+  it("subscribe notifies on transitions", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    const listener = vi.fn();
+    client.subscribe(listener);
+
+    client.send({ type: "INCREMENT" });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].public.count).toBe(1);
+  });
+
+  it("unsubscribe stops notifications", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    const listener = vi.fn();
+    const unsub = client.subscribe(listener);
+    unsub();
+
+    client.send({ type: "INCREMENT" });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("returns caller-scoped snapshot", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    client.send({ type: "INCREMENT" });
+
+    const state = client.getState();
+    expect(state.public.count).toBe(1);
+    expect(state.private.accessCount).toBe(1);
+    expect(state.value).toBeDefined();
+  });
+
+  it("accepts custom input props", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+      input: { initialCount: 50 },
+    });
+
+    expect(client.getState().public.count).toBe(50);
+  });
+
+  it("connect and disconnect are no-ops (don't throw)", async () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    await expect(client.connect()).resolves.toBeUndefined();
+    expect(() => client.disconnect()).not.toThrow();
+  });
+
+  it("waitFor resolves when condition is met", async () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    // Already at 0 — condition met
+    await expect(
+      client.waitFor((s) => s.public.count === 0)
+    ).resolves.toBeUndefined();
+  });
+
+  it("select() works on machine client", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    const count = client.select((s) => s.public.count);
+    expect(count.get()).toBe(0);
+
+    client.send({ type: "INCREMENT" });
+    expect(count.get()).toBe(1);
+  });
+
+  it("trigger works on machine client", () => {
+    const client = createActorKitMachineClient({
+      machine: counterMachine,
+      caller: { type: "client", id: "user-1" },
+    });
+
+    client.trigger.INCREMENT();
+    expect(client.getState().public.count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `createActorKitMachineClient()` to `actor-kit/test`
- Runs the real XState machine — guards evaluated, actions executed
- Coexists with `createActorKitMockClient` (snapshot-only)
- Full `ActorKitClient` interface: select(), trigger, waitFor, subscribe

## Test plan
- [x] 11 new tests: guards, actions, subscribe, caller scoping, select, trigger
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)