### PR TITLE
Add Hono + actor-kit example with workers integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ reports
 docs/specs/states/
 docs/specs/tla2tools.jar
 storybook-static
+.wrangler
+*.sqlite

--- a/examples/hono-server/package.json
+++ b/examples/hono-server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "hono-actorkit-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev --port 8787",
+    "deploy": "wrangler deploy",
+    "cf-typegen": "wrangler types",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@actor-kit/types": "workspace:*",
+    "@actor-kit/worker": "workspace:*",
+    "@actor-kit/server": "workspace:*",
+    "hono": "^4.7.0",
+    "xstate": "^5.28.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.13.2",
+    "@cloudflare/workers-types": "^4.20260312.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0",
+    "wrangler": "^4.75.0"
+  }
+}

--- a/examples/hono-server/src/counter.ts
+++ b/examples/hono-server/src/counter.ts
@@ -1,0 +1,143 @@
+/**
+ * Counter actor — a simple incrementable counter as a Durable Object.
+ */
+import type {
+  ActorKitSystemEvent,
+  AnyActorServer,
+  BaseActorKitEvent,
+  WithActorKitEvent,
+  WithActorKitInput,
+} from "@actor-kit/types";
+import { createMachineServer } from "@actor-kit/worker";
+import { assign, setup } from "xstate";
+import { z } from "zod";
+
+// --- Env ---
+
+export interface Env {
+  COUNTER: DurableObjectNamespace<InstanceType<typeof Counter>>;
+  ACTOR_KIT_SECRET: string;
+  [key: string]: DurableObjectNamespace<AnyActorServer> | unknown;
+}
+
+// --- Schemas ---
+
+export const CounterClientEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("INCREMENT") }),
+  z.object({ type: z.literal("DECREMENT") }),
+  z.object({ type: z.literal("SET"), value: z.number() }),
+]);
+
+export const CounterServiceEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("RESET") }),
+]);
+
+export const CounterInputPropsSchema = z.object({
+  initialCount: z.number().optional(),
+});
+
+// --- Types ---
+
+type CounterClientEvent = z.infer<typeof CounterClientEventSchema>;
+type CounterServiceEvent = z.infer<typeof CounterServiceEventSchema>;
+
+type CounterEvent = (
+  | WithActorKitEvent<CounterClientEvent, "client">
+  | WithActorKitEvent<CounterServiceEvent, "service">
+  | ActorKitSystemEvent
+) &
+  BaseActorKitEvent<Env>;
+
+type CounterInput = WithActorKitInput<
+  z.infer<typeof CounterInputPropsSchema>,
+  Env
+>;
+
+type CounterContext = {
+  public: { count: number; lastUpdatedBy: string | null };
+  private: Record<string, { accessCount: number }>;
+};
+
+// --- Machine ---
+
+const counterMachine = setup({
+  types: {
+    context: {} as CounterContext,
+    events: {} as CounterEvent,
+    input: {} as CounterInput,
+  },
+  actions: {
+    increment: assign({
+      public: ({ context, event }) => ({
+        ...context.public,
+        count: context.public.count + 1,
+        lastUpdatedBy: event.caller.id,
+      }),
+      private: ({ context, event }) => ({
+        ...context.private,
+        [event.caller.id]: {
+          accessCount:
+            (context.private[event.caller.id]?.accessCount ?? 0) + 1,
+        },
+      }),
+    }),
+    decrement: assign({
+      public: ({ context, event }) => ({
+        ...context.public,
+        count: context.public.count - 1,
+        lastUpdatedBy: event.caller.id,
+      }),
+    }),
+    setValue: assign({
+      public: ({ context, event }) => {
+        if (event.type !== "SET") return context.public;
+        return {
+          ...context.public,
+          count: event.value,
+          lastUpdatedBy: event.caller.id,
+        };
+      },
+    }),
+    resetCounter: assign({
+      public: ({ context }) => ({
+        ...context.public,
+        count: 0,
+        lastUpdatedBy: null,
+      }),
+    }),
+  },
+}).createMachine({
+  id: "counter",
+  type: "parallel",
+  context: ({ input }: { input: CounterInput }) => ({
+    public: {
+      count: input.initialCount ?? 0,
+      lastUpdatedBy: null,
+    },
+    private: {},
+  }),
+  states: {
+    Operations: {
+      on: {
+        INCREMENT: { actions: ["increment"] },
+        DECREMENT: { actions: ["decrement"] },
+        SET: { actions: ["setValue"] },
+        RESET: { actions: ["resetCounter"] },
+      },
+    },
+  },
+});
+
+export type CounterMachine = typeof counterMachine;
+
+// --- Durable Object ---
+
+export const Counter = createMachineServer({
+  machine: counterMachine,
+  schemas: {
+    clientEvent: CounterClientEventSchema,
+    serviceEvent: CounterServiceEventSchema,
+    inputProps: CounterInputPropsSchema,
+  },
+  options: { persisted: true },
+});

--- a/examples/hono-server/src/index.ts
+++ b/examples/hono-server/src/index.ts
@@ -1,0 +1,202 @@
+/**
+ * Hono + actor-kit example.
+ *
+ * Shows how to use actor-kit DOs with your own routing — no createActorKitRouter needed.
+ * Each route interacts with the DO stub directly via RPC methods.
+ */
+import { Hono } from "hono";
+import { createAccessToken } from "@actor-kit/server";
+import { getCallerFromRequest } from "@actor-kit/worker";
+import type { Env } from "./counter";
+
+// Re-export the DO class for wrangler
+export { Counter } from "./counter";
+
+const app = new Hono<{ Bindings: Env }>();
+
+// ---------------------------------------------------------------------------
+// Helper: get a typed DO stub by name
+// ---------------------------------------------------------------------------
+
+function getCounterStub(env: Env, counterId: string) {
+  const id = env.COUNTER.idFromName(counterId);
+  return env.COUNTER.get(id);
+}
+
+// ---------------------------------------------------------------------------
+// Public routes
+// ---------------------------------------------------------------------------
+
+app.get("/", (c) =>
+  c.json({
+    message: "Hono + actor-kit counter example",
+    endpoints: {
+      "GET /counter/:id": "Get counter snapshot (needs auth)",
+      "POST /counter/:id/increment": "Increment counter (needs auth)",
+      "POST /counter/:id/decrement": "Decrement counter (needs auth)",
+      "POST /counter/:id/reset": "Reset counter (needs auth, service only)",
+      "GET /counter/:id/ws": "WebSocket connection (needs auth)",
+      "POST /token": "Get an access token",
+    },
+  })
+);
+
+// ---------------------------------------------------------------------------
+// Token endpoint — in a real app this lives in your auth layer
+// ---------------------------------------------------------------------------
+
+app.post("/token", async (c) => {
+  const body = await c.req.json<{
+    counterId: string;
+    userId: string;
+    callerType?: "client" | "service";
+  }>();
+
+  const token = await createAccessToken({
+    signingKey: c.env.ACTOR_KIT_SECRET,
+    actorId: body.counterId,
+    actorType: "counter",
+    callerId: body.userId,
+    callerType: body.callerType ?? "client",
+  });
+
+  return c.json({ token });
+});
+
+// ---------------------------------------------------------------------------
+// Auth middleware — extract caller from JWT Bearer token
+// ---------------------------------------------------------------------------
+
+app.use("/counter/:id/*", async (c, next) => {
+  try {
+    const caller = await getCallerFromRequest(
+      c.req.raw,
+      "counter",
+      c.req.param("id"),
+      c.env.ACTOR_KIT_SECRET
+    );
+    c.set("caller" as never, caller as never);
+    await next();
+  } catch {
+    return c.json({ error: "Unauthorized — provide Bearer token" }, 401);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Counter routes — each route is explicit, typed, composable
+// ---------------------------------------------------------------------------
+
+// GET /counter/:id — get the current snapshot
+app.get("/counter/:id", async (c) => {
+  const stub = getCounterStub(c.env, c.req.param("id"));
+  const caller = c.get("caller" as never) as { id: string; type: string };
+
+  // Ensure actor is spawned (idempotent)
+  stub.spawn({
+    actorType: "counter",
+    actorId: c.req.param("id"),
+    caller: caller as { id: string; type: "client" | "service" | "system" },
+    input: {},
+  });
+
+  const result = await stub.getSnapshot(
+    caller as { id: string; type: "client" | "service" | "system" }
+  );
+  return c.json(result);
+});
+
+// POST /counter/:id/increment
+app.post("/counter/:id/increment", async (c) => {
+  const stub = getCounterStub(c.env, c.req.param("id"));
+  const caller = c.get("caller" as never) as {
+    id: string;
+    type: "client" | "service" | "system";
+  };
+
+  stub.spawn({
+    actorType: "counter",
+    actorId: c.req.param("id"),
+    caller,
+    input: {},
+  });
+
+  stub.send({ type: "INCREMENT", caller });
+
+  const result = await stub.getSnapshot(caller);
+  return c.json(result);
+});
+
+// POST /counter/:id/decrement
+app.post("/counter/:id/decrement", async (c) => {
+  const stub = getCounterStub(c.env, c.req.param("id"));
+  const caller = c.get("caller" as never) as {
+    id: string;
+    type: "client" | "service" | "system";
+  };
+
+  stub.spawn({
+    actorType: "counter",
+    actorId: c.req.param("id"),
+    caller,
+    input: {},
+  });
+
+  stub.send({ type: "DECREMENT", caller });
+
+  const result = await stub.getSnapshot(caller);
+  return c.json(result);
+});
+
+// POST /counter/:id/reset — service-only
+app.post("/counter/:id/reset", async (c) => {
+  const stub = getCounterStub(c.env, c.req.param("id"));
+  const caller = c.get("caller" as never) as {
+    id: string;
+    type: "client" | "service" | "system";
+  };
+
+  if (caller.type !== "service") {
+    return c.json({ error: "Only service callers can reset" }, 403);
+  }
+
+  stub.spawn({
+    actorType: "counter",
+    actorId: c.req.param("id"),
+    caller,
+    input: {},
+  });
+
+  stub.send({ type: "RESET", caller });
+
+  const result = await stub.getSnapshot(caller);
+  return c.json(result);
+});
+
+// GET /counter/:id/ws — WebSocket upgrade (forward to DO)
+app.get("/counter/:id/ws", async (c) => {
+  if (c.req.header("Upgrade") !== "websocket") {
+    return c.json({ error: "Expected WebSocket upgrade" }, 426);
+  }
+
+  const stub = getCounterStub(c.env, c.req.param("id"));
+  const caller = c.get("caller" as never) as {
+    id: string;
+    type: "client" | "service" | "system";
+  };
+
+  stub.spawn({
+    actorType: "counter",
+    actorId: c.req.param("id"),
+    caller,
+    input: {},
+  });
+
+  // Forward the WebSocket upgrade to the DO
+  return stub.fetch(c.req.raw);
+});
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export default app;

--- a/examples/hono-server/tests/counter.test.ts
+++ b/examples/hono-server/tests/counter.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Workers integration tests for the Hono + actor-kit example.
+ *
+ * Runs inside the Workers runtime via @cloudflare/vitest-pool-workers.
+ * Tests the full Hono route → DO RPC → state machine → response flow.
+ */
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+// Helper: get an access token from the /token endpoint
+async function getToken(
+  counterId: string,
+  userId: string,
+  callerType: "client" | "service" = "client"
+) {
+  const res = await SELF.fetch("http://localhost/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ counterId, userId, callerType }),
+  });
+  const body = (await res.json()) as { token: string };
+  return body.token;
+}
+
+// Helper: make an authenticated request
+function authedFetch(url: string, token: string, options?: RequestInit) {
+  return SELF.fetch(url, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+type SnapshotResponse = {
+  snapshot: {
+    public: { count: number; lastUpdatedBy: string | null };
+    private: { accessCount?: number };
+    value: unknown;
+  };
+  checksum: string;
+};
+
+describe("Hono counter API", () => {
+  it("GET / returns endpoint list", async () => {
+    const res = await SELF.fetch("http://localhost/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { endpoints: Record<string, string> };
+    expect(body.endpoints).toHaveProperty("GET /counter/:id");
+  });
+
+  it("POST /token returns a valid JWT", async () => {
+    const token = await getToken("test-1", "user-1");
+    expect(token).toBeTruthy();
+    expect(token.split(".")).toHaveLength(3); // JWT format
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await SELF.fetch("http://localhost/counter/test-2");
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /counter/:id returns initial snapshot", async () => {
+    const token = await getToken("test-3", "user-1");
+    const res = await authedFetch("http://localhost/counter/test-3", token);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as SnapshotResponse;
+    expect(body.snapshot.public.count).toBe(0);
+    expect(body.snapshot.public.lastUpdatedBy).toBeNull();
+    expect(body.checksum).toBeTruthy();
+  });
+
+  it("POST /counter/:id/increment increases count", async () => {
+    const token = await getToken("test-4", "user-1");
+
+    const res = await authedFetch(
+      "http://localhost/counter/test-4/increment",
+      token,
+      { method: "POST" }
+    );
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as SnapshotResponse;
+    expect(body.snapshot.public.count).toBe(1);
+    expect(body.snapshot.public.lastUpdatedBy).toBe("user-1");
+  });
+
+  it("POST /counter/:id/decrement decreases count", async () => {
+    const token = await getToken("test-5", "user-1");
+
+    // Increment first
+    await authedFetch("http://localhost/counter/test-5/increment", token, {
+      method: "POST",
+    });
+    await authedFetch("http://localhost/counter/test-5/increment", token, {
+      method: "POST",
+    });
+
+    // Then decrement
+    const res = await authedFetch(
+      "http://localhost/counter/test-5/decrement",
+      token,
+      { method: "POST" }
+    );
+    const body = (await res.json()) as SnapshotResponse;
+    expect(body.snapshot.public.count).toBe(1);
+  });
+
+  it("tracks per-caller private context", async () => {
+    const token = await getToken("test-6", "user-1");
+
+    await authedFetch("http://localhost/counter/test-6/increment", token, {
+      method: "POST",
+    });
+    await authedFetch("http://localhost/counter/test-6/increment", token, {
+      method: "POST",
+    });
+
+    const res = await authedFetch("http://localhost/counter/test-6", token);
+    const body = (await res.json()) as SnapshotResponse;
+    expect(body.snapshot.private.accessCount).toBe(2);
+  });
+
+  it("different callers see their own private context", async () => {
+    const token1 = await getToken("test-7", "user-1");
+    const token2 = await getToken("test-7", "user-2");
+
+    // User 1 increments 3 times
+    for (let i = 0; i < 3; i++) {
+      await authedFetch("http://localhost/counter/test-7/increment", token1, {
+        method: "POST",
+      });
+    }
+
+    // User 2 increments once
+    await authedFetch("http://localhost/counter/test-7/increment", token2, {
+      method: "POST",
+    });
+
+    // User 1 sees accessCount=3
+    const res1 = await authedFetch("http://localhost/counter/test-7", token1);
+    const body1 = (await res1.json()) as SnapshotResponse;
+    expect(body1.snapshot.private.accessCount).toBe(3);
+    expect(body1.snapshot.public.count).toBe(4); // shared
+
+    // User 2 sees accessCount=1
+    const res2 = await authedFetch("http://localhost/counter/test-7", token2);
+    const body2 = (await res2.json()) as SnapshotResponse;
+    expect(body2.snapshot.private.accessCount).toBe(1);
+    expect(body2.snapshot.public.count).toBe(4); // same shared state
+  });
+
+  it("POST /counter/:id/reset requires service caller", async () => {
+    const clientToken = await getToken("test-8", "user-1");
+    const serviceToken = await getToken("test-8", "admin", "service");
+
+    // Increment first
+    await authedFetch("http://localhost/counter/test-8/increment", clientToken, {
+      method: "POST",
+    });
+
+    // Client can't reset
+    const failRes = await authedFetch(
+      "http://localhost/counter/test-8/reset",
+      clientToken,
+      { method: "POST" }
+    );
+    expect(failRes.status).toBe(403);
+
+    // Service can reset
+    const okRes = await authedFetch(
+      "http://localhost/counter/test-8/reset",
+      serviceToken,
+      { method: "POST" }
+    );
+    expect(okRes.status).toBe(200);
+    const body = (await okRes.json()) as SnapshotResponse;
+    expect(body.snapshot.public.count).toBe(0);
+  });
+});
+
+describe("WebSocket", () => {
+  it("upgrades to WebSocket and receives state patches", async () => {
+    const token = await getToken("ws-test-1", "user-1");
+
+    // Spawn the actor first via GET
+    await authedFetch("http://localhost/counter/ws-test-1", token);
+
+    // Connect WebSocket
+    const res = await authedFetch(
+      `http://localhost/counter/ws-test-1/ws?accessToken=${token}`,
+      token,
+      { headers: { Upgrade: "websocket" } }
+    );
+
+    expect(res.status).toBe(101);
+    expect(res.webSocket).toBeTruthy();
+
+    const ws = res.webSocket!;
+    ws.accept();
+
+    // Collect messages
+    const messages: string[] = [];
+    ws.addEventListener("message", (event) => {
+      messages.push(typeof event.data === "string" ? event.data : "");
+    });
+
+    // Wait for initial state patch
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Increment via HTTP — should trigger a WebSocket patch
+    await authedFetch("http://localhost/counter/ws-test-1/increment", token, {
+      method: "POST",
+    });
+
+    // Wait for the patch to arrive
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Should have received at least one message with operations
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+
+    const lastMessage = JSON.parse(messages[messages.length - 1]) as {
+      operations: unknown[];
+      checksum: string;
+    };
+    expect(lastMessage.operations).toBeDefined();
+    expect(lastMessage.checksum).toBeTruthy();
+
+    // Close gracefully — catch expected workerd cleanup error
+    try { ws.close(); } catch { /* workerd may already have closed */ }
+  });
+});

--- a/examples/hono-server/tsconfig.json
+++ b/examples/hono-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/hono-server/vitest.config.ts
+++ b/examples/hono-server/vitest.config.ts
@@ -1,0 +1,14 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      wrangler: { configPath: "./wrangler.toml" },
+    }),
+  ],
+  test: {
+    include: ["tests/**/*.test.ts"],
+    testTimeout: 15000,
+  },
+});

--- a/examples/hono-server/wrangler.toml
+++ b/examples/hono-server/wrangler.toml
@@ -1,0 +1,15 @@
+name = "hono-actorkit-example"
+main = "src/index.ts"
+compatibility_date = "2024-09-25"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+ACTOR_KIT_SECRET = "dev-secret-change-in-prod"
+
+[[durable_objects.bindings]]
+name = "COUNTER"
+class_name = "Counter"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["Counter"]


### PR DESCRIPTION
## Summary
Demonstrates using actor-kit DOs with Hono routing instead of `createActorKitRouter`.
Shows that the building blocks (DO RPC, `getCallerFromRequest`, `createAccessToken`)
compose naturally with any framework.

- `examples/hono-server/` — Hono counter API with JWT auth middleware
- 10 workers integration tests (HTTP API + WebSocket)

## What this proves
You don't need `createActorKitRouter`. The primitives are:
1. `createMachineServer()` — defines the DO
2. `env.COUNTER.get(id)` — native Cloudflare stub
3. `stub.spawn()` / `stub.send()` / `stub.getSnapshot()` — DO RPC
4. `getCallerFromRequest()` / `createAccessToken()` — auth

## Test plan
- [x] 10 workers integration tests (CRUD, auth, private context, WebSocket)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)